### PR TITLE
Fix Qiskit Nature warning about `dict_aux_operators`

### DIFF
--- a/circuit_knitting_toolbox/__init__.py
+++ b/circuit_knitting_toolbox/__init__.py
@@ -11,3 +11,8 @@
 # that they have been altered from the originals.
 
 """Main Circuit Knitting Toolbox public functionality."""
+
+from qiskit_nature.settings import settings
+
+# This will suppress a warning about an upcoming change in Qiskit Nature
+settings.dict_aux_operators = True

--- a/circuit_knitting_toolbox/entanglement_forging/cholesky_decomposition.py
+++ b/circuit_knitting_toolbox/entanglement_forging/cholesky_decomposition.py
@@ -62,6 +62,11 @@ def get_cholesky_op(
     Returns:
         - cholesky_operator: The converted operator
     """
+    # This will suppress a warning about an upcoming change in Qiskit Nature
+    from qiskit_nature.settings import settings
+
+    settings.dict_aux_operators = True
+
     cholesky_int = OneBodyElectronicIntegrals(
         basis=ElectronicBasis.SO, matrices=l_op[:, :, g]
     )


### PR DESCRIPTION
Currently, we can see many warnings like the following:

```
ListAuxOpsDeprecationWarning: List-based `aux_operators` are deprecated as of version 0.3.0 and support for them will be removed no sooner than 3 months after the release. Instead, use dict-based `aux_operators`. You can switch to the dict-based interface immediately, by setting `qiskit_nature.settings.dict_aux_operators` to `True`.
```

This actually has to be set in two places: somewhere "top level" (either in the driving code or in the CKT `__init__.py`) as well as in `get_cholesky_op` (which is run under Ray).

Ordinarily, I'd say that a library shouldn't mess with settings like this, but I think in this case we may as well just set this in `__init__.py` for a few reasons:
- The "deprecated" way predates the toolkit, and it is unlikely that anyone is going to be needing to use the old interface with the toolkit.
- If a user really wants to, they can adjust the setting back, and it will still work -- they'll just get the warning.
- Telling every user to set this manually else see a warning for the near future is cumbersome and distracting.

Somewhat beyond me, but I've found that the warning is only suppressed if the `from qiskit_nature.settings import settings` is placed _within_ the `get_cholesky_op` function -- it cannot be at the top of `cholesky-decomposition.py`.