### PR TITLE
Add `coverage` environment to `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.25
-envlist = py{37,38,39}{,-notebook}, lint, mypy
+envlist = py{37,38,39}{,-notebook}, lint, mypy, coverage
 isolated_build = True
 
 [testenv]
@@ -31,6 +31,16 @@ extras =
   notebook-dependencies
 commands =
   pytest --nbmake --nbmake-timeout=3000 --ignore-glob=*serverless* docs/
+
+[testenv:coverage]
+deps =
+  {[testenv]deps}
+  coverage>=5.5
+commands =
+  coverage3 run --source circuit_knitting_toolbox --parallel-mode -m pytest test/ {posargs}
+  coverage3 combine
+  coverage3 html
+  coverage3 report --fail-under=50
 
 [pytest]
 addopts = --doctest-modules


### PR DESCRIPTION
Right now, the coverage measures at 57% for, so I set `--fail-under=50` in this configuration.