### PR TITLE
Skip dependencies on platforms where they are known to be broken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A software prototype for a circuit knitting toolbox which connect
 requires-python = ">=3.7"
 
 dependencies = [
-    "pyscf>=2.0.1",
+    "pyscf>=2.0.1; sys_platform != 'win32' and (python_version < '3.10' or sys_platform != 'darwin')",
     "qiskit-aer>=0.11.0",
     "qiskit-terra>=0.21.1",
     "qiskit-nature>=0.4.2",
@@ -18,7 +18,7 @@ dependencies = [
     "nptyping>=2.1.1",
     "ray>=1.13.0",
     "docplex>=2.23.222",
-    "cplex>=22.1.0.0",
+    "cplex>=22.1.0.0; platform_machine != 'arm64'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This skips the install of pyscf and cplex on platforms where they are known to be broken.

This is ready to merge, but going forward, there are a few things we ought to consider:

- The toolkit itself does not seem to depend on pyscf; instead, some of the tests and notebooks depend on it via `PySCFDriver`.  With this in mind, does pyscf actually belong in the dependency list for the toolkit?  I propose that we instead move it to two optional dependency lists: `tests` and `notebook-dependencies`.
- The toolkit only depends _implicitly_ on cplex through its use of docplex.  If cplex is missing, a [rather long traceback](https://gist.github.com/garrison/b0e233aee58032ae404305024f5c9886) results currently.  It would be nice to find a way to give the user a more helpful error message when this happens (e.g., suggest installing cplex or using a platform where it is supported, else using within a Docker container).