### PR TITLE
Combine tox lint environments into one

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,4 +29,4 @@ jobs:
         run: |
           eval $(ssh-agent -s)
           ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
-          tox -e docstring,lint,mypy
+          tox -elint

--- a/tox.ini
+++ b/tox.ini
@@ -14,21 +14,13 @@ commands =
 basepython = python3.9
 deps =
   black[jupyter]==22.3.0
+  pydocstyle
+  mypy==0.961
+  # pydocstyle prefers to parse our pyproject.toml, hence the following line
+  toml
 commands =
   black --check circuit_knitting_toolbox/ docs/ test/ tools/
-  
-[testenv:docstring]
-basepython = python3.9
-deps =
-  pydocstyle
-commands =
   pydocstyle circuit_knitting_toolbox/
-
-[testenv:mypy]
-basepython = python3.9
-deps =
-  mypy==0.961
-commands =
   mypy circuit_knitting_toolbox/
 
 [testenv:{py37-,py38-,py39-,}notebook]


### PR DESCRIPTION
Previously, we had three environments: lint, pydocstyle, and mypy. It's easier for the user to only have to remember one command, and it will run a bit quicker on CI when it is no longer necessary to construct multiple virtual environments, I expect.