### PR TITLE
Add circuit cutting API references to Sphinx build

### DIFF
--- a/circuit_knitting_toolbox/circuit_cutting/__init__.py
+++ b/circuit_knitting_toolbox/circuit_cutting/__init__.py
@@ -17,4 +17,12 @@ Circuit Cutting (:mod:`circuit_knitting_toolbox.circuit_cutting`).
 .. autosummary::
    :toctree: ../stubs/
    :nosignatures:
+
+    wire_cutting.run_subcircuit_instances
+    wire_cutting.generate_summation_terms
+    wire_cutting.build
+    wire_cutting.verify
+    wire_cutting.cut_circuit_wires
+    wire_cutting.evaluate_subcircuits
+    wire_cutting.reconstruct_full_distribution
 """

--- a/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting.py
+++ b/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting.py
@@ -43,8 +43,8 @@ def cut_circuit_wires(
         - max_subcircuit_size (int, optional): max number of gates in a subcircuit
         - verbose (bool, optional): flag for printing output of cutting
     Returns:
-        - (Dict[str, Any]): A dictionary containing information on the cuts,
-            including the subcircuits themselves (key: 'subcircuits')
+        (Dict[str, Any]): A dictionary containing information on the cuts,
+        including the subcircuits themselves (key: 'subcircuits')
     Raises:
         - ValueError: if the input method does not match the other provided arguments
     """
@@ -94,8 +94,8 @@ def evaluate_subcircuits(
         - options (Union[Options, Sequence[Options]]): Options to use on each backend
         - backend_names (Union[str, Sequence[str]]): The name(s) of the backend(s) to be used
     Returns:
-        - (Dict): the dictionary containing the results from running
-            each of the subcircuits
+        (Dict): the dictionary containing the results from running
+        each of the subcircuits
     """
     # Put backend_names and options in lists to ensure it is unambiguous how to sync them
     backends_list: Sequence[str] = []

--- a/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting_post_processing.py
+++ b/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting_post_processing.py
@@ -236,14 +236,14 @@ def generate_summation_terms(
 
     Final CutQC reconstruction result = Sum(summation_terms).
 
-    summation_terms (list) : [summation_term_0, summation_term_1, ...] --> 4^#cuts elements.
+    summation_terms (list): [summation_term_0, summation_term_1, ...] --> 4^#cuts elements.
 
-    summation_term[subcircuit_idx] = subcircuit_entry_idx.
-    E.g. summation_term = {0:0,1:13,2:7} = Kron(subcircuit_0_entry_0, subcircuit_1_entry_13, subcircuit_2_entry_7).
+    | summation_term[subcircuit_idx] = subcircuit_entry_idx.
+    | E.g. summation_term = {0:0,1:13,2:7} = Kron(subcircuit_0_entry_0, subcircuit_1_entry_13, subcircuit_2_entry_7).
 
-    subcircuit_entries[subcircuit_idx][init_label,meas_label] = subcircuit_entry_idx, kronecker_term.
-    kronecker_term (list): (coefficient, subcircuit_instance_idx).
-    Add coefficient*subcircuit_instance to subcircuit_entry.
+    | subcircuit_entries[subcircuit_idx][init_label,meas_label] = subcircuit_entry_idx, kronecker_term.
+    | kronecker_term (list): (coefficient, subcircuit_instance_idx).
+    | Add coefficient*subcircuit_instance to subcircuit_entry.
 
     subcircuit_instances[subcircuit_idx][init,meas] = subcircuit_instance_idx.
 
@@ -253,6 +253,9 @@ def generate_summation_terms(
         - num_cuts (int): the number of cuts
 
     Returns:
+        a tuple
+        containing:
+
         - (dict): dictionary containing information on the summation terms
         - (dict): dictionary containing the subcircuits entry information
         - (dict): dictionary containing subcircuit instances
@@ -398,8 +401,11 @@ def build(
         - num_threads (int): the number of threads to use for multithreading
 
     Returns:
+        a tuple
+        containing:
+
         - (NDArray): the reconstructed probability distribution of the full
-            circuit
+          circuit
         - (list): the ordering of the distribution
         - (dict): the computational post-processing overhead
     """

--- a/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting_verification.py
+++ b/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting_verification.py
@@ -48,9 +48,12 @@ def verify(
             execution of the subcircuits
 
     Returns:
-        - (dict): a dictionary containing a variety of distributional difference metrics for the
-            ground truth and reconstructed distributions
-        - (Sequence[float]): the true probability distribution of the full circuit
+        a tuple
+        containing:
+
+        - a dictionary containing a variety of distributional difference
+          metrics for the ground truth and reconstructed distributions; and,
+        - the true probability distribution of the full circuit
     """
     ground_truth = _evaluate_circuit(circuit=full_circuit)
     metrics = {}


### PR DESCRIPTION
The most important change is in `__init__.py`.  The others changes are to fix formatting issues and a few Sphinx warnings (which would otherwise be treated as errors, since we are passing the `-W` flag to Sphinx).