### PR TITLE
Pin coverage to < 7 when running coveragepy-lcov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
-          pip install tox coveragepy-lcov
+          pip install tox coveragepy-lcov 'coverage<7'
       - name: Run coverage
         run: |
           tox -e coverage


### PR DESCRIPTION
coverage 7.0.0 removed `FnmatchMatcher`, which coverage-lcov currently depends on.
https://github.com/chaychoong/coveragepy-lcov/issues/5

We can unpin this once coverage-lcov has been fixed.