### PR TITLE
Speed up kronecker product

### DIFF
--- a/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting_post_processing.py
+++ b/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting_post_processing.py
@@ -371,9 +371,11 @@ def naive_compute(
             if summation_term_prob is None:
                 summation_term_prob = subcircuit_entry_prob
             else:
-                summation_term_prob = np.kron(
-                    summation_term_prob, subcircuit_entry_prob
-                )
+                summation_term_prob = (
+                    summation_term_prob[:, None,]*subcircuit_entry_prob[None, :,]
+                    ).reshape(
+                        summation_term_prob.size * subcircuit_entry_prob.size
+                    ) 
                 overhead["multiplications"] += len(summation_term_prob)
         if reconstructed_prob is None:
             reconstructed_prob = summation_term_prob

--- a/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting_post_processing.py
+++ b/circuit_knitting_toolbox/circuit_cutting/wire_cutting/wire_cutting_post_processing.py
@@ -15,7 +15,6 @@ import multiprocessing as mp
 from typing import Dict, Sequence, Union, Tuple, List, Optional, Any
 
 
-import numpy as np
 from nptyping import NDArray
 from qiskit import QuantumCircuit
 from qiskit.circuit import Qubit
@@ -372,10 +371,15 @@ def naive_compute(
                 summation_term_prob = subcircuit_entry_prob
             else:
                 summation_term_prob = (
-                    summation_term_prob[:, None,]*subcircuit_entry_prob[None, :,]
-                    ).reshape(
-                        summation_term_prob.size * subcircuit_entry_prob.size
-                    ) 
+                    summation_term_prob[
+                        :,
+                        None,
+                    ]
+                    * subcircuit_entry_prob[
+                        None,
+                        :,
+                    ]
+                ).reshape(summation_term_prob.size * subcircuit_entry_prob.size)
                 overhead["multiplications"] += len(summation_term_prob)
         if reconstructed_prob is None:
             reconstructed_prob = summation_term_prob


### PR DESCRIPTION
Rewrote Kronecker product calculation to not use `np.kron` function. This is because using this numpy function for vector calculations is very computationally expensive.  This PR can speed up the reconstruction time as the following image. 

Experiment Environment:
- Cut random circuits of 29 and 30 qubit
- max_subcircuit_width=10, max_cut=10

<img width="814" alt="image" src="https://user-images.githubusercontent.com/18023178/228272468-bcda3831-05a0-4ae1-ad60-cd5c0fc0259c.png">
