### PR TITLE
Set `platform: linux/amd64` in `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.4"
 services:
   notebook:
     build: .
+    platform: linux/amd64
     restart: unless-stopped
     # The following line allows Ray to use /dev/shm rather than warn
     # about using /tmp


### PR DESCRIPTION
By default, Docker running on a Mac M1 chip will create a container that is native to M1.  However, for the purposes of the toolkit, we need to install cplex, which only is built for Intel.  So we set the platform explicitly in the `docker-compose.yml` file, which tells the M1 chip to use its `x86_64` emulation instead.