### PR TITLE
Remove dependency on `qiskit-ibmq-provider`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "qiskit-terra>=0.22.0",
     "qiskit-nature>=0.4.4",
     "qiskit-ibm-runtime>=0.7.0",
-    "qiskit-ibmq-provider>=0.19.2",
     "nptyping>=2.1.1",
     "docplex>=2.23.222",
     "cplex>=22.1.0.0; platform_machine != 'arm64'",


### PR DESCRIPTION
`qiskit-ibmq-provider` has been deprecated as of Qiskit 0.40.  We actually don't seem to be using it at all in ckt anymore, so we can safely remove it from the dependencies.