### PR TITLE
Add support for reno release notes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
+        fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
-        fetch-depth: 0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
+        fetch-depth: 0
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-        fetch-depth: 0
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ extensions = [
     # "sphinx.ext.autosectionlabel",
     "jupyter_sphinx",
     "sphinx_autodoc_typehints",
-    # "reno.sphinxext",
+    "reno.sphinxext",
     "nbsphinx",
     "sphinx_copybutton",
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Contents
   Explanatory Material <explanation/index>
   How-To Guides <how-tos/index>
   API References <apidocs/index>
+  Release Notes <release-notes>
 
 .. Hiding - Indices and tables
    :ref:`genindex`

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,0 +1,1 @@
+.. release-notes:: Release Notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ lint = [
     "circuit-knitting-toolbox[style]",
     "pydocstyle==6.1.1",
     "mypy==0.982",
+    "reno>=3.4.0",
     # pydocstyle prefers to parse our pyproject.toml, hence the following line
     "toml",
 ]
@@ -62,6 +63,7 @@ docs = [
     "jupyter-sphinx>=0.3.2",
     "nbsphinx>=0.8.8",
     "sphinx-copybutton>=0.5.0",
+    "reno>=3.4.0",
 ]
 notebook-dependencies = [
     "quantum-serverless>=0.0.1",

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,0 +1,3 @@
+---
+encoding: utf8
+default_branch: main

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ commands =
   black --check circuit_knitting_toolbox/ docs/ test/ tools/
   pydocstyle circuit_knitting_toolbox/
   mypy circuit_knitting_toolbox/
+  reno lint
 
 [testenv:{py37-,py38-,py39-,py310-,}notebook]
 deps =


### PR DESCRIPTION
This adds support for reno, so that we can have an explicit "release notes" section in our docs.  This also puts us in line with the practices of Qiskit and the Qiskit application modules.

This will be distinct from the PR summary that gets added to the [release page](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/releases) for each release.  It will allow us to more thoroughly document new features, deprecations, and other changes in the toolbox.