### PR TITLE
Add `project.urls` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ notebook-dependencies = [
     "pylatexenc",
 ]
 
+[project.urls]
+"Documentation" = "https://qiskit-extensions.github.io/circuit-knitting-toolbox/"
+"Repository" = "https://github.com/Qiskit-Extensions/circuit-knitting-toolbox"
+
 [tool.autoflake]
 remove-unused-variables = true
 remove-all-unused-imports = true


### PR DESCRIPTION
Upon the next release, this will enable urls for the repo and docs to be shown on pypi.