### PR TITLE
Deprecate support for Python 3.7

### DIFF
--- a/circuit_knitting_toolbox/__init__.py
+++ b/circuit_knitting_toolbox/__init__.py
@@ -11,7 +11,19 @@
 
 """Main Circuit Knitting Toolbox public functionality."""
 
+import sys
+import warnings
+
 from qiskit_nature.settings import settings
 
 # This will suppress a warning about an upcoming change in Qiskit Nature
 settings.dict_aux_operators = True
+
+if sys.version_info < (3, 8):
+    warnings.warn(
+        "Using the Circuit Knitting Toolbox with Python 3.7 is deprecated."
+        "Support for Python 3.7 will be removed in the near future, as soon as "
+        "https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/pull/80 "
+        "is merged.",
+        DeprecationWarning,
+    )


### PR DESCRIPTION
In order to give users following the `main` branch even more of a "heads up" about the pending removal of Python 3.7 support, we can merge this PR immediately, which will warn them if they are using Python 3.7.  Then, we can wait and merge #80 later (in a few weeks, most likely), just before we want to add code that supports only Python 3.8 and higher.

I did not add a release note here, because we have no plans to make another release before dropping Python 3.7 support.