### PR TITLE
Install *all* notebook dependencies in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,4 @@ RUN mkdir docs && \
     cp -a .src/circuit-knitting-toolbox/docs docs/circuit-knitting-toolbox
 
 # Pip install everything
-RUN pip install ipywidgets pylatexenc matplotlib \
-        -e .src/circuit-knitting-toolbox
+RUN pip install -e '.src/circuit-knitting-toolbox[notebook-dependencies]'


### PR DESCRIPTION
This installs _all_ the notebook dependencies given in `pyproject.toml` instead of listing a few explicitly.  Thus, this means (i) less code duplication; and (ii) all notebooks will work when used inside Docker.

I had to wonder for a moment why I didn't just do this originally when the `Dockerfile` was added as part of #2.  Here's why: Then, the quantum-serverless repository was private, and there was no simple & secure way that we knew of for users to pass their ssh private key to the Docker build.  So, we simply did not install quantum-serverless within Docker at the time.

I've tested each tutorial notebook locally (and within Docker) with this change, and they all work.