### PR TITLE
Enable monthly dependabot updates for the linters

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,12 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels: ["dependencies"]
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    labels: ["dependencies"]
+    versioning-strategy: increase
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This enables monthly dependabot updates for all packages whose versions are precisely pinned in `pyproject.toml`, which for us is various linters.  This way, we will have a sense of (i) which linters have updates available; (ii) which linters can be updated immediately without causing any errors; and (iii) when a linter can't be immediately updated, an automated CI log of what first needs to be fixed.  I believe monthly is the appropriate cadence for these checks; I really don't want to be bothered more often than that with linter updates, but I don't want them to get _way_ out of date either without us noticing.

One thing that _might_ become annoying is various black updates, but if that occurs we can later tell dependabot to ignore them.

I first experimented with this on a personal fork of ckt.  See [here](https://github.com/garrison/circuit-knitting-toolbox/pulls?q=is%3Apr+label%3Adependencies) for the activity that dependabot created on my repository.  The only difference with this PR is that the PRs here (and there going forward) will have the label `dependencies` but _not_ the label `python`, since `labels` is explicitly provided in the yml.