### PR TITLE
Temporarily disable qiskit-nature development version test

### DIFF
--- a/tools/extremal_dependency_versions.py
+++ b/tools/extremal_dependency_versions.py
@@ -21,7 +21,7 @@ def mapfunc_dev(dep):
     """Load the development version(s) of certain Qiskit-related packages"""
     # https://peps.python.org/pep-0440/#direct-references
     return re.sub(
-        r"^(qiskit-(?:terra|nature|ibm-runtime)).*$",
+        r"^(qiskit-(?:terra|ibm-runtime)).*$",
         r"\1 @ git+https://github.com/Qiskit/\1.git",
         dep,
     )


### PR DESCRIPTION
Now that https://github.com/Qiskit/qiskit-nature/pull/1142 has been merged, our "development version tests" are going to [fail](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/actions/runs/4826062552) on `main` until #83 is merged.  This change fixes CI immediately by excluding the development version of qiskit-nature from these tests.  This change should be reverted as part of #83 before it is merged.