### PR TITLE
Use a released version of the coveralls workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Convert to lcov
         run: coveragepy-lcov --output_file_path coveralls.info
       - name: Upload report to Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coveralls.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,4 +39,5 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coveralls.info
+          file: coveralls.info
+          format: lcov


### PR DESCRIPTION
I noticed when tracking down a [coveralls failure](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/pull/120#issuecomment-1527727777) that we are using the `master` version of the workflow, even though the [README](https://github.com/marketplace/actions/coveralls-github-action) now suggests to use `v2`.  Here, I've updated this.  There's no good reason at this point to rely explicitly on their development version.