### PR TITLE
Add release note following Python 3.7 deprecation

### DIFF
--- a/releasenotes/notes/deprecate-py37-5ef642682641aeb8.yaml
+++ b/releasenotes/notes/deprecate-py37-5ef642682641aeb8.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    Support for running with Python 3.7 has been deprecated.  Future
+    versions of the Circuit Knitting Toolbox will require Python 3.8
+    or higher.


### PR DESCRIPTION
Python 3.7 was deprecated in #87, but we did not add a release note then because we did not expect to make a release before removing Python 3.7 support.  Now, plans have changed, so we should add the note.