### PR TITLE
Improve errors when cplex is not installed

### DIFF
--- a/circuit_knitting_toolbox/circuit_cutting/wire_cutting/mip_model.py
+++ b/circuit_knitting_toolbox/circuit_cutting/wire_cutting/mip_model.py
@@ -493,7 +493,13 @@ class MIPModel(object):
             min_postprocessing_cost,
             str(type(min_postprocessing_cost)),
         )
-        self.model.export_as_lp(path="./docplex_cutter.lp")
+        try:
+            self.model.export_as_lp(path="./docplex_cutter.lp")
+        except RuntimeError:
+            print(
+                "The LP file export has failed.  This is known to happen sometimes "
+                "when cplex is not installed.  Now attempting to continue anyway."
+            )
         try:
             self.model.set_time_limit(300)
             if min_postprocessing_cost != float("inf"):
@@ -504,10 +510,10 @@ class MIPModel(object):
 
         except DOcplexException as e:
             print("Caught: " + e.message)
+            raise e
 
         if self.model._has_solution:
             my_solve_details = self.model.solve_details
-            self.objective = None
             self.subcircuits = []
             self.optimal = self.model.get_solve_status() == "optimal"
             self.runtime = my_solve_details.time

--- a/circuit_knitting_toolbox/circuit_cutting/wire_cutting/mip_model.py
+++ b/circuit_knitting_toolbox/circuit_cutting/wire_cutting/mip_model.py
@@ -515,7 +515,7 @@ class MIPModel(object):
         if self.model._has_solution:
             my_solve_details = self.model.solve_details
             self.subcircuits = []
-            self.optimal = self.model.get_solve_status() == "optimal"
+            self.optimal = my_solve_details.status == "optimal"
             self.runtime = my_solve_details.time
             self.node_count = my_solve_details.nb_nodes_processed
             self.mip_gap = my_solve_details.mip_relative_gap


### PR DESCRIPTION
This improves the error messages when cplex is not installed.  Closes #119.

Formerly:

> RuntimeError: dictionary changed size during iteration

With this change:

> DOcplexException: Cannot solve model: no CPLEX runtime found.

Also, I removed an unnecessary line and fixed a deprecation notice which said:

> DeprecationWarning: Model.get_solve_status() is deprecated with cloud solve, use Model.solve_details instead

Initially, I was going to add this change to #109, but then I decided that it is so basic that it should really go in first.