### PR TITLE
List `pyscf` explicitly as an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,15 @@ cplex = [
     "docplex>=2.23.222; python_version < '3.11' and platform_machine != 'arm64'",
     "cplex>=22.1.0.0; python_version < '3.11' and platform_machine != 'arm64'",
 ]
+pyscf = [
+    "pyscf>=2.0.1; sys_platform != 'win32'",
+]
 dev = [
     "circuit-knitting-toolbox[test,lint]",
     "nbmake",
 ]
 test = [
-    "pyscf>=2.0.1; sys_platform != 'win32'",
+    "circuit-knitting-toolbox[pyscf]",
     "pytest>=6.2.5",
     "pytest-randomly>=1.2.0",
 ]
@@ -71,9 +74,8 @@ docs = [
     "reno>=3.4.0",
 ]
 notebook-dependencies = [
-    "circuit-knitting-toolbox[cplex]",
+    "circuit-knitting-toolbox[cplex,pyscf]",
     "quantum-serverless>=0.0.7",
-    "pyscf>=2.0.1; sys_platform != 'win32'",
     "matplotlib",
     "ipywidgets",
     "pylatexenc",


### PR DESCRIPTION
This will allow users to `pip install circuit-knitting-toolbox[pyscf]` or `pip install circuit-knitting-toolbox[pyscf,cplex]` if they want everything.  (`pip install circuit-knitting-toolbox[notebook-dependencies]` already installs both, and a few other things.)  This also removes duplication of the desired `pyscf` version.