### PR TITLE
Skip slow tests by default (but not in CI)

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -41,4 +41,4 @@ jobs:
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          tox -epy${pver/./},py${pver/./}-notebook
+          tox -epy${pver/./},py${pver/./}-notebook -- --run-slow

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -41,4 +41,5 @@ jobs:
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          tox -epy${pver/./},py${pver/./}-notebook -- --run-slow
+          tox -epy${pver/./} -- --run-slow
+          tox -epy${pver/./}-notebook

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -43,10 +43,10 @@ jobs:
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          tox -epy${pver/./}
+          tox -epy${pver/./} -- --run-slow
           if [ "$pver" = "3.11" ]; then
             echo Skipping tutorials that require cplex
-            tox -epy${pver/./}-notebook  -- --ignore=docs/circuit_cutting/tutorials/tutorial_1_automatic_cut_finding.ipynb --ignore=docs/circuit_cutting/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb -- --run-slow
+            tox -epy${pver/./}-notebook  -- --ignore=docs/circuit_cutting/tutorials/tutorial_1_automatic_cut_finding.ipynb --ignore=docs/circuit_cutting/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb
           else
-            tox -epy${pver/./}-notebook -- --run-slow
+            tox -epy${pver/./}-notebook
           fi

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -46,7 +46,7 @@ jobs:
           tox -epy${pver/./}
           if [ "$pver" = "3.11" ]; then
             echo Skipping tutorials that require cplex
-            tox -epy${pver/./}-notebook  -- --ignore=docs/circuit_cutting/tutorials/tutorial_1_automatic_cut_finding.ipynb --ignore=docs/circuit_cutting/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb
+            tox -epy${pver/./}-notebook  -- --ignore=docs/circuit_cutting/tutorials/tutorial_1_automatic_cut_finding.ipynb --ignore=docs/circuit_cutting/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb -- --run-slow
           else
-            tox -epy${pver/./}-notebook
+            tox -epy${pver/./}-notebook -- --run-slow
           fi

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -40,4 +40,5 @@ jobs:
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          tox -epy${pver/./},py${pver/./}-notebook -- --run-slow
+          tox -epy${pver/./} -- --run-slow
+          tox -epy${pver/./}-notebook

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -40,4 +40,4 @@ jobs:
         shell: bash
         run: |
           pver=${{ matrix.python-version }}
-          tox -epy${pver/./},py${pver/./}-notebook
+          tox -epy${pver/./},py${pver/./}-notebook -- --run-slow

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,39 @@
+# This code is a Qiskit project.
+
+# (C) Copyright IBM 2023.
+
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Pytest configuration for Circuit Knitting Toolbox"""
+
+import pytest
+
+
+# https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+
+
+# pylint: disable=missing-function-docstring
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip-slow",
+        action="store_true",
+        default=False,
+        help="skip slow tests",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--skip-slow"):
+        skip_slow = pytest.mark.skip(reason="skipping slow test, as --skip-slow was provided")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,7 +33,9 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--skip-slow"):
-        skip_slow = pytest.mark.skip(reason="skipping slow test, as --skip-slow was provided")
+        skip_slow = pytest.mark.skip(
+            reason="skipping slow test, as --skip-slow was provided"
+        )
         for item in items:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,10 +20,10 @@ import pytest
 # pylint: disable=missing-function-docstring
 def pytest_addoption(parser):
     parser.addoption(
-        "--skip-slow",
+        "--run-slow",
         action="store_true",
         default=False,
-        help="skip slow tests",
+        help="run slow tests",
     )
 
 
@@ -32,9 +32,9 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--skip-slow"):
+    if not config.getoption("--run-slow"):
         skip_slow = pytest.mark.skip(
-            reason="skipping slow test, as --skip-slow was provided"
+            reason="skipping slow test, as --run-slow was not provided"
         )
         for item in items:
             if "slow" in item.keywords:

--- a/test/entanglement_forging/test_entanglement_forging_ground_state_solver.py
+++ b/test/entanglement_forging/test_entanglement_forging_ground_state_solver.py
@@ -35,7 +35,6 @@ class TestEntanglementForgingGroundStateSolver(unittest.TestCase):
         # Hard-code some ansatz params/lambdas
         self.optimizer = SPSA(maxiter=0)
 
-    @pytest.mark.slow
     def test_entanglement_forging_vqe_hydrogen(self):
         """Test of applying Entanglement Forged Solver to to compute the energy of a H2 molecule."""
         # Set up the ElectronicStructureProblem

--- a/test/entanglement_forging/test_entanglement_forging_ground_state_solver.py
+++ b/test/entanglement_forging/test_entanglement_forging_ground_state_solver.py
@@ -12,6 +12,7 @@
 """Tests for EntanglementForgingVQE module."""
 
 import unittest
+import pytest
 import numpy as np
 
 from qiskit.algorithms.optimizers import SPSA
@@ -34,6 +35,7 @@ class TestEntanglementForgingGroundStateSolver(unittest.TestCase):
         # Hard-code some ansatz params/lambdas
         self.optimizer = SPSA(maxiter=0)
 
+    @pytest.mark.slow
     def test_entanglement_forging_vqe_hydrogen(self):
         """Test of applying Entanglement Forged Solver to to compute the energy of a H2 molecule."""
         # Set up the ElectronicStructureProblem

--- a/test/entanglement_forging/test_entanglement_forging_ground_state_solver.py
+++ b/test/entanglement_forging/test_entanglement_forging_ground_state_solver.py
@@ -12,7 +12,6 @@
 """Tests for EntanglementForgingVQE module."""
 
 import unittest
-import pytest
 import numpy as np
 
 from qiskit.algorithms.optimizers import SPSA

--- a/test/entanglement_forging/test_entanglement_forging_knitter.py
+++ b/test/entanglement_forging/test_entanglement_forging_knitter.py
@@ -72,7 +72,6 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
 
         return ansatz
 
-    @pytest.mark.slow
     def test_entanglement_forging_H2(self):
         """
         Test to apply Entanglement Forging to compute the energy of a H2 molecule,
@@ -187,7 +186,6 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(energy + energy_shift, -75.68366174497027)
 
-    @pytest.mark.slow
     def test_entanglement_forging_driver_H2(self):
         """Test for entanglement forging driver."""
         hcore = np.array([[-1.12421758, -0.9652574], [-0.9652574, -1.12421758]])

--- a/test/entanglement_forging/test_entanglement_forging_knitter.py
+++ b/test/entanglement_forging/test_entanglement_forging_knitter.py
@@ -13,6 +13,8 @@
 
 import os
 import unittest
+import pytest
+
 import numpy as np
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import TwoLocal
@@ -70,6 +72,7 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
 
         return ansatz
 
+    @pytest.mark.slow
     def test_entanglement_forging_H2(self):
         """
         Test to apply Entanglement Forging to compute the energy of a H2 molecule,
@@ -106,6 +109,7 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(energy + energy_shift, -1.121936544469326)
 
+    @pytest.mark.slow
     def test_entanglement_forging_H2O(self):  # pylint: disable=too-many-locals
         """
         Test to apply Entanglement Forging to compute the energy of a H20 molecule,
@@ -183,6 +187,7 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(energy + energy_shift, -75.68366174497027)
 
+    @pytest.mark.slow
     def test_entanglement_forging_driver_H2(self):
         """Test for entanglement forging driver."""
         hcore = np.array([[-1.12421758, -0.9652574], [-0.9652574, -1.12421758]])
@@ -226,6 +231,7 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(energy + energy_shift, -1.1219365445030705)
 
+    @pytest.mark.slow
     def test_asymmetric_bitstrings_O2(self):
         """Test for entanglement forging driver."""
         hamiltonian = ElectronicEnergy.from_raw_integrals(self.hcore_o2, self.eri_o2)
@@ -262,6 +268,7 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(energy + energy_shift, -147.63645235088566)
 
+    @pytest.mark.slow
     def test_asymmetric_bitstrings_CH3(self):
         """Test for entanglement forging driver."""
         hamiltonian = ElectronicEnergy.from_raw_integrals(self.hcore_ch3, self.eri_ch3)
@@ -300,6 +307,7 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(energy + energy_shift, -39.09031477502881)
 
+    @pytest.mark.slow
     def test_asymmetric_bitstrings_CN(self):
         """Test for asymmetric bitstrings with hybrid cross terms."""
         hamiltonian = ElectronicEnergy.from_raw_integrals(self.hcore_cn, self.eri_cn)

--- a/test/entanglement_forging/test_entanglement_forging_knitter.py
+++ b/test/entanglement_forging/test_entanglement_forging_knitter.py
@@ -108,7 +108,6 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(energy + energy_shift, -1.121936544469326)
 
-    @pytest.mark.slow
     def test_entanglement_forging_H2O(self):  # pylint: disable=too-many-locals
         """
         Test to apply Entanglement Forging to compute the energy of a H20 molecule,

--- a/test/entanglement_forging/test_entanglement_forging_knitter.py
+++ b/test/entanglement_forging/test_entanglement_forging_knitter.py
@@ -265,7 +265,6 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(energy + energy_shift, -147.63645235088566)
 
-    @pytest.mark.slow
     def test_asymmetric_bitstrings_CH3(self):
         """Test for entanglement forging driver."""
         hamiltonian = ElectronicEnergy.from_raw_integrals(self.hcore_ch3, self.eri_ch3)

--- a/test/entanglement_forging/test_entanglement_forging_knitter.py
+++ b/test/entanglement_forging/test_entanglement_forging_knitter.py
@@ -110,7 +110,7 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
 
     def test_entanglement_forging_H2O(self):  # pylint: disable=too-many-locals
         """
-        Test to apply Entanglement Forging to compute the energy of a H20 molecule,
+        Test to apply Entanglement Forging to compute the energy of a H2O molecule,
         given optimal ansatz parameters.
         """
         # setup problem

--- a/tox.ini
+++ b/tox.ini
@@ -61,4 +61,4 @@ commands =
   sphinx-build -b html -W -T --keep-going {posargs} docs/ docs/_build/html
 
 [pytest]
-addopts = --doctest-modules
+addopts = --doctest-modules --durations=10

--- a/tox.ini
+++ b/tox.ini
@@ -61,4 +61,4 @@ commands =
   sphinx-build -b html -W -T --keep-going {posargs} docs/ docs/_build/html
 
 [pytest]
-addopts = --doctest-modules --durations=10
+addopts = -rs --doctest-modules --durations=10

--- a/tox.ini
+++ b/tox.ini
@@ -61,4 +61,4 @@ commands =
   sphinx-build -b html -W -T --keep-going {posargs} docs/ docs/_build/html
 
 [pytest]
-addopts = -rs --doctest-modules --durations=10
+addopts = --doctest-modules -rs --durations=10


### PR DESCRIPTION
This marks a number of the entanglement forging tests as being "slow."  These slow tests are run by default (and in CI), but they can be excluded by passing the option `--skip-slow` to pytest.  For instance, the command `tox -epy3 -- --skip-slow` runs very quickly.

I am hoping that this helps us iterate more quickly, as the code we are soon to migrate over has a very nice test suite with 100% coverage that executes in only a few seconds.