### PR TITLE
Set unreleased version title in reno config

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,3 +1,4 @@
 ---
 encoding: utf8
 default_branch: main
+unreleased_version_title: "Upcoming release (``main`` branch)"


### PR DESCRIPTION
This replaces the header "0.1.0-1" (or similar) at https://qiskit-extensions.github.io/circuit-knitting-toolbox/release-notes.html with "Upcoming release (`main` branch)".

![reno-upcoming-release](https://user-images.githubusercontent.com/91987/236593127-82b7e682-0481-4a3c-9b1c-374c1b16adbc.png)
