### PR TITLE
Change `gate.operation` -> `instruction.operation`

### DIFF
--- a/circuit_knitting_toolbox/circuit_cutting/qpd/qpd.py
+++ b/circuit_knitting_toolbox/circuit_cutting/qpd/qpd.py
@@ -371,8 +371,8 @@ def _decompose_qpd_measurements(
     # here because it refers to old indices, before the decomposition.
     qpd_measure_ids = [
         i
-        for i, gate in enumerate(circuit.data)
-        if gate.operation.name.lower() == "qpd_measure"
+        for i, instruction in enumerate(circuit.data)
+        if instruction.operation.name.lower() == "qpd_measure"
     ]
 
     # Create a classical register for the qpd measurement results.  This is


### PR DESCRIPTION
Currently, there are a few loops that use the variable `gate` for a `CircuitInstruction`.  This changes those to use the variable name `instruction` instead.  This removes the nonsensical `gate.operation` phrasing.  (`.operation` _might_ be a gate, but it is not in general.)