### PR TITLE
Add `overhead` property to `QPDBasis`

### DIFF
--- a/circuit_knitting_toolbox/circuit_cutting/qpd/qpd_basis.py
+++ b/circuit_knitting_toolbox/circuit_cutting/qpd/qpd_basis.py
@@ -127,7 +127,7 @@ class QPDBasis:
         Returns:
             - (float): The sampling overhead
         """
-        return self._kappa ** 2
+        return self._kappa**2
 
     @staticmethod
     def from_gate(gate: Gate) -> "QPDBasis":

--- a/circuit_knitting_toolbox/circuit_cutting/qpd/qpd_basis.py
+++ b/circuit_knitting_toolbox/circuit_cutting/qpd/qpd_basis.py
@@ -110,7 +110,7 @@ class QPDBasis:
         """
         Get the square root of the sampling overhead.
 
-        The sampling overhead is the square of the sum of the magnitude of the coefficients.
+        This quantity is the sum of the magnitude of the coefficients.
 
         Returns:
             - (float): The square root of the sampling overhead

--- a/circuit_knitting_toolbox/circuit_cutting/qpd/qpd_basis.py
+++ b/circuit_knitting_toolbox/circuit_cutting/qpd/qpd_basis.py
@@ -108,14 +108,26 @@ class QPDBasis:
     @property
     def kappa(self) -> float:
         """
-        Get the sampling overhead.
+        Get the square root of the sampling overhead.
 
-        The sampling overhead is calculated by summing the magnitude of the coefficients.
+        The sampling overhead is the square of the sum of the magnitude of the coefficients.
 
         Returns:
-            - (float): The kappa member variable
+            - (float): The square root of the sampling overhead
         """
         return self._kappa
+
+    @property
+    def overhead(self) -> float:
+        """
+        Get the sampling overhead.
+
+        The sampling overhead is the square of the sum of the magnitude of the coefficients.
+
+        Returns:
+            - (float): The sampling overhead
+        """
+        return self._kappa ** 2
 
     @staticmethod
     def from_gate(gate: Gate) -> "QPDBasis":

--- a/test/circuit_cutting/qpd/test_qpd_basis.py
+++ b/test/circuit_cutting/qpd/test_qpd_basis.py
@@ -155,6 +155,7 @@ class TestQPDBasis(unittest.TestCase):
 
         self.assertTrue(all(new_qpd.probabilities == new_qpd2.probabilities))
         self.assertTrue(new_qpd.kappa == new_qpd2.kappa)
+        self.assertTrue(new_qpd.overhead == new_qpd2.kappa ** 2)
 
     def test_mismatching_indices(self):
         maps = [(None, "M")]

--- a/test/circuit_cutting/qpd/test_qpd_basis.py
+++ b/test/circuit_cutting/qpd/test_qpd_basis.py
@@ -155,7 +155,7 @@ class TestQPDBasis(unittest.TestCase):
 
         self.assertTrue(all(new_qpd.probabilities == new_qpd2.probabilities))
         self.assertTrue(new_qpd.kappa == new_qpd2.kappa)
-        self.assertTrue(new_qpd.overhead == new_qpd2.kappa ** 2)
+        self.assertTrue(new_qpd.overhead == new_qpd2.kappa**2)
 
     def test_mismatching_indices(self):
         maps = [(None, "M")]


### PR DESCRIPTION
`QPDBasis` has a property called `kappa`, but that is hardly a standard name.  It's defined in https://arxiv.org/abs/2205.00016, but the first author of that paper instead uses the term "C-factor" is his [master thesis](https://www.research-collection.ethz.ch/handle/20.500.11850/504508).  Another paper, https://arxiv.org/abs/2006.11174, uses the symbol `W(U)` for the same quantity.  `gamma` is perhaps more well established, but it refers specifically to the _optimal_ value of kappa, and we may do decompositions that are less than optimal.

Thus, this introduces a property called `overhead`, which _is_ a standard term to represent kappa^2.  This is typically the quantity we are interested in, so we can show query it in the tutorials instead of computing kappa^2.