### PR TITLE
Add `Reset` support to the simulator

### DIFF
--- a/circuit_knitting_toolbox/utils/simulation.py
+++ b/circuit_knitting_toolbox/utils/simulation.py
@@ -12,6 +12,8 @@
 """Simulation of precise measurement outcome probabilities."""
 from __future__ import annotations
 
+from collections import defaultdict
+
 import numpy as np
 from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import Statevector, Operator
@@ -23,62 +25,83 @@ _TOLERANCE = 1e-16
 def simulate_statevector_outcomes(qc: QuantumCircuit, /) -> dict[int, float]:
     """Return each classical outcome along with its precise probability.
 
-    Circuit can contain mid-circuit, projective measurements, but classical bits cannot be written more than once.
+    Circuit can contain mid-circuit, projective measurements.
+
+    All gates are supported, along with measurements and reset operations.
     """
-    current = {0: (1.0, Statevector.from_int(0, 2**qc.num_qubits))}
-    processed_clbit_indices = set()
+    current = defaultdict(list)
+    current[0].append((1.0, Statevector.from_int(0, 2**qc.num_qubits)))
     for inst in qc.data:
-        if len(inst.clbits) == 0:
-            # Evolve each statevector according to the current instruction
-            for _, sv in current.values():
-                # Calling `_evolve_instruction` rather than `evolve` allows us
-                # to avoid a copy.
-                Statevector._evolve_instruction(
-                    sv, inst.operation, [qc.find_bit(q)[0] for q in inst.qubits]
-                )
+        opname = inst.operation.name
+        if opname in ("measure", "reset"):
+            # The current instruction is not unitary: it's either a measurement
+            # or a reset.
+            qubit_idx = qc.find_bit(inst.qubits[0])[0]
+            if opname == "measure":
+                # We will need to set a classical bit depending on the
+                # measurement result.  `k_flipper` locates that bit.
+                k_flipper = 1 << qc.find_bit(inst.clbits[0])[0]
+            else:
+                # It's a reset operation, so we will not be modifying any
+                # classical bits.
+                k_flipper = 0
+            # We need to keep track of the statevector and corresponding
+            # probability of *both* possible outcomes (although, we truncate
+            # states if their probability becomes less than _TOLERANCE).  In
+            # the following, we loop through each outcome so far and prepare to
+            # update the state.
+            pending_delete: list[tuple[int, int]] = []
+            pending_insert: list[tuple[int, tuple[float, Statevector]]] = []
+            for k, svs in current.items():
+                k0 = k ^ (k & k_flipper)  # like k, but k_flipper bit will NOT be set
+                k1 = k | k_flipper  # like k, but k_flipper bit (if any) will be set
+                for i, (prob, sv) in enumerate(svs):
+                    (prob0, prob1) = sv.probabilities([qubit_idx])
+                    dims = sv.dims([qubit_idx])  # always going to be (2,) for a qubit
+                    pending_delete.append((k, i))
+                    # Handle the 0 branch of the wave function
+                    if not np.isclose(prob0, 0, atol=_TOLERANCE):
+                        proj0 = np.diag([1 / np.sqrt(prob0), 0.0])
+                        sv0 = sv.evolve(
+                            Operator(proj0, input_dims=dims, output_dims=dims),
+                            qargs=[qubit_idx],
+                        )
+                        pending_insert.append((k0, (prob * prob0, sv0)))
+                    # Handle the 1 branch of the wave function
+                    if not np.isclose(prob1, 0, atol=_TOLERANCE):
+                        proj1 = np.diag([0.0, 1 / np.sqrt(prob1)])
+                        if k_flipper == 0:
+                            # It's a reset operation, so we need to rotate the 1
+                            # result back to 0 by applying the same rotation as
+                            # the X gate.
+                            proj1 = np.array([(0, 1), (1, 0)]) @ proj1
+                        sv1 = sv.evolve(
+                            Operator(proj1, input_dims=dims, output_dims=dims),
+                            qargs=[qubit_idx],
+                        )
+                        pending_insert.append((k1, (prob * prob1, sv1)))
+            # A dict's keys cannot be changed while iterating it, so we perform
+            # all such updates now that iteration over the dict is complete.
+            for k, i in reversed(pending_delete):
+                del current[k][i]
+            for k, v in pending_insert:
+                current[k].append(v)
+            # We might as well clean up empty lists, too.
+            for k in [k for k, v in current.items() if not v]:
+                del current[k]
         else:
-            if inst.operation.name != "measure":
+            # The current instruction is a unitary operation (i.e., a gate).
+            if len(inst.clbits) != 0:
                 raise ValueError(
                     "Circuit cannot contain a non-measurement operation on classical bit(s)."
                 )  # pragma: no cover
-            qubit_idx = qc.find_bit(inst.qubits[0])[0]
-            clbit_idx = qc.find_bit(inst.clbits[0])[0]
-            if clbit_idx in processed_clbit_indices:
-                raise ValueError(
-                    "Circuits that overwrite a classical bit are not supported."
-                )
-            processed_clbit_indices.add(clbit_idx)
-            # The current instruction is a measurement, so we need to keep
-            # track of the statevector and corresponding probability of *both*
-            # possible outcomes (although, we truncate states if their
-            # probability becomes less than _TOLERANCE).  In the following, we
-            # loop through each outcome so far and prepare to update the state.
-            pending_delete: list[int] = []
-            pending_insert: list[tuple[int, tuple[float, Statevector]]] = []
-            for k, (prob, sv) in current.items():
-                (prob0, prob1) = sv.probabilities([qubit_idx])
-                dims = sv.dims([qubit_idx])  # always going to be (2,) for a qubit
-                if np.isclose(prob0, 0, atol=_TOLERANCE):
-                    pending_delete.append(k)
-                else:
-                    proj0 = np.diag([1 / np.sqrt(prob0), 0.0])
-                    sv0 = sv.evolve(
-                        Operator(proj0, input_dims=dims, output_dims=dims),
-                        qargs=[qubit_idx],
+            # Evolve each statevector according to the current instruction
+            for svs in current.values():
+                for _, sv in svs:
+                    # Calling `_evolve_instruction` rather than `evolve` allows
+                    # us to avoid a copy.
+                    Statevector._evolve_instruction(
+                        sv, inst.operation, [qc.find_bit(q)[0] for q in inst.qubits]
                     )
-                    current[k] = (prob * prob0, sv0)
-                if not np.isclose(prob1, 0, atol=_TOLERANCE):
-                    proj1 = np.diag([0.0, 1 / np.sqrt(prob1)])
-                    sv1 = sv.evolve(
-                        Operator(proj1, input_dims=dims, output_dims=dims),
-                        qargs=[qubit_idx],
-                    )
-                    pending_insert.append((k | (1 << clbit_idx), (prob * prob1, sv1)))
-            # A dict's keys cannot be changed while iterating it, so we perform
-            # all such updates now that iteration over the dict is complete.
-            for k in pending_delete:
-                del current[k]
-            for k, v in pending_insert:
-                current[k] = v
 
-    return {outcome: prob for outcome, (prob, sv) in current.items()}
+    return {outcome: sum(prob for prob, _ in svs) for outcome, svs in current.items()}

--- a/test/utils/test_simulation.py
+++ b/test/utils/test_simulation.py
@@ -43,17 +43,14 @@ class TestSimulationFunctions(unittest.TestCase):
             assert r.keys() == {0}
             assert r[0] == pytest.approx(1.0)
 
-        with self.subTest("Error when overwriting clbits"):
+        with self.subTest("Overwriting clbits"):
             qc = QuantumCircuit(2, 1)
             qc.h(0)
             qc.measure(0, 0)
             qc.measure(1, 0)
-            with pytest.raises(ValueError) as e_info:
-                simulate_statevector_outcomes(qc)
-            assert (
-                e_info.value.args[0]
-                == "Circuits that overwrite a classical bit are not supported."
-            )
+            r = simulate_statevector_outcomes(qc)
+            assert r.keys() == {0}
+            assert r[0] == pytest.approx(1.0)
 
         with self.subTest("Bit has probability 1 of being set"):
             qc = QuantumCircuit(1, 1)
@@ -61,3 +58,14 @@ class TestSimulationFunctions(unittest.TestCase):
             qc.measure(0, 0)
             r = simulate_statevector_outcomes(qc)
             assert r.keys() == {1}
+
+        with self.subTest("Circuit with reset operation"):
+            qc = QuantumCircuit(1, 2)
+            qc.h(0)
+            qc.measure(0, 0)
+            qc.reset(0)
+            qc.measure(0, 1)
+            r = simulate_statevector_outcomes(qc)
+            assert r.keys() == {0, 1}
+            assert r[0] == pytest.approx(0.5)
+            assert r[1] == pytest.approx(0.5)


### PR DESCRIPTION
This adds support for reset operations to the simulator.  In doing so, it also removes the restriction that classical bits can only be written once.

This change is necessary to support the tests for wire cutting.