### PR TITLE
Use exact weights in `generate_qpd_samples` when it's possible for _all_ of them

### DIFF
--- a/test/circuit_cutting/qpd/test_qpd.py
+++ b/test/circuit_cutting/qpd/test_qpd.py
@@ -89,6 +89,16 @@ class TestQPDFunctions(unittest.TestCase):
             for decomp_ids in samples.keys():
                 self.assertTrue(0 <= decomp_ids[0] < len(self.qpd_gate1.basis.maps))
                 self.assertTrue(0 <= decomp_ids[1] < len(self.qpd_gate2.basis.maps))
+        with self.subTest("HWEA exact weights"):
+            # Do the same thing with num_samples above the threshold for exact weights
+            basis_ids = [9, 20]
+            bases = [self.qpd_circuit.data[i].operation.basis for i in basis_ids]
+            samples = generate_qpd_samples(bases, num_samples=1000)
+            assert sum(w for w, t in samples.values()) == pytest.approx(1000)
+            assert all(t == WeightType.EXACT for w, t in samples.values())
+            for decomp_ids in samples.keys():
+                self.assertTrue(0 <= decomp_ids[0] < len(self.qpd_gate1.basis.maps))
+                self.assertTrue(0 <= decomp_ids[1] < len(self.qpd_gate2.basis.maps))
 
     def test_decompose_qpd_instructions(self):
         with self.subTest("Empty circuit"):


### PR DESCRIPTION
This changes `generate_qpd_samples` to use exact weights when it's possible for _all_ of them, i.e., it's either all or nothing, for now at least.  I am working on a subsequent PR that will allow a mixture: the weights above the `1 / num_samples` threshold will be evaluated exactly, while everything else will be sampled.   However, that's a bit more complex, and this will suffice for some of the basic use cases (e.g., cutting CNOTs only).