### PR TITLE
Update `tox.ini` to use Python 3.10 in coverage workflow

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ commands =
   pytest --nbmake --nbmake-timeout=3000 {posargs} docs/
 
 [testenv:coverage]
+basepython = python3.10
 deps =
   coverage>=5.5
 extras =


### PR DESCRIPTION
Even though the coverage workflow passes CI, it's been failing for Caleb and me locally.  Specifically, it's erroneously showing that the following `continue` statement is not covered:

https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/b919f99d2ab6b54e63397769697ba19b2363ab62/circuit_knitting_toolbox/circuit_cutting/cutting_decomposition.py#L65-L70

After discovering the comment at https://github.com/nedbat/coveragepy/issues/1530#issuecomment-1520879380, I decided to try setting the Python version to 3.10, as that's what CI uses.  With this change, the coverage workflow now passes for me locally.

I am not sure if this has the same root problem at https://github.com/nedbat/coveragepy/issues/1530, but I suspect that it may.