### PR TITLE
Don't add empty cregs to circuits

### DIFF
--- a/circuit_knitting_toolbox/circuit_cutting/qpd/qpd.py
+++ b/circuit_knitting_toolbox/circuit_cutting/qpd/qpd.py
@@ -384,23 +384,24 @@ def _decompose_qpd_measurements(
         if instruction.operation.name.lower() == "qpd_measure"
     ]
 
-    # Create a classical register for the qpd measurement results.  This is
-    # partly for convenience, partly to work around
-    # https://github.com/Qiskit/qiskit-aer/issues/1660.
-    reg = ClassicalRegister(len(qpd_measure_ids), name="qpd_measurements")
-    circuit.add_register(reg)
+    if len(qpd_measure_ids) > 0:
+        # Create a classical register for the qpd measurement results.  This is
+        # partly for convenience, partly to work around
+        # https://github.com/Qiskit/qiskit-aer/issues/1660.
+        reg = ClassicalRegister(len(qpd_measure_ids), name="qpd_measurements")
+        circuit.add_register(reg)
 
-    # Place the measurement instructions
-    for idx, i in enumerate(qpd_measure_ids):
-        gate = circuit.data[i]
-        inst = CircuitInstruction(
-            operation=Measure(), qubits=[gate.qubits], clbits=[reg[idx]]
-        )
-        circuit.data[i] = inst
+        # Place the measurement instructions
+        for idx, i in enumerate(qpd_measure_ids):
+            gate = circuit.data[i]
+            inst = CircuitInstruction(
+                operation=Measure(), qubits=[gate.qubits], clbits=[reg[idx]]
+            )
+            circuit.data[i] = inst
 
-    # If the user wants to access the qpd register, it will be the final
-    # classical register of the returned circuit.
-    assert circuit.cregs[-1] is reg
+        # If the user wants to access the qpd register, it will be the final
+        # classical register of the returned circuit.
+        assert circuit.cregs[-1] is reg
 
     return circuit
 

--- a/test/circuit_cutting/qpd/test_qpd.py
+++ b/test/circuit_cutting/qpd/test_qpd.py
@@ -104,7 +104,6 @@ class TestQPDFunctions(unittest.TestCase):
         with self.subTest("Empty circuit"):
             circ = QuantumCircuit()
             new_circ = decompose_qpd_instructions(QuantumCircuit(), [])
-            circ.add_register(ClassicalRegister(0, name="qpd_measurements"))
             self.assertEqual(circ, new_circ)
         with self.subTest("No QPD circuit"):
             circ = QuantumCircuit(2, 1)
@@ -112,7 +111,6 @@ class TestQPDFunctions(unittest.TestCase):
             circ.cx(0, 1)
             circ.measure(1, 0)
             new_circ = decompose_qpd_instructions(circ, [])
-            circ.add_register(ClassicalRegister(0, name="qpd_measurements"))
             self.assertEqual(circ, new_circ)
         with self.subTest("Single QPD gate"):
             circ = QuantumCircuit(2)


### PR DESCRIPTION
This PR prevents qpd._decompose_qpd_measurements from adding empty QPD registers. This came up while creating unit tests for #153 . Removing the empty registers makes it more clear what is happening under the hood and makes it more straightforward to test against.