### PR TITLE
Allow `num_samples` to be a float

### DIFF
--- a/test/circuit_cutting/qpd/test_qpd.py
+++ b/test/circuit_cutting/qpd/test_qpd.py
@@ -110,7 +110,6 @@ class TestQPDFunctions(unittest.TestCase):
                 self.assertTrue(0 <= decomp_ids[0] < len(self.qpd_gate1.basis.maps))
                 self.assertTrue(0 <= decomp_ids[1] < len(self.qpd_gate2.basis.maps))
         with self.subTest("HWEA exact weights via 'infinite' num_samples"):
-            # Do the same thing with num_samples above the threshold for exact weights
             basis_ids = [9, 20]
             bases = [self.qpd_circuit.data[i].operation.basis for i in basis_ids]
             samples = generate_qpd_samples(bases, num_samples=math.inf)


### PR DESCRIPTION
This change allows `num_samples` to be a float.  This really only has one immediate impact: one can pass `math.inf` as `num_samples` and get exact weights (no sampled ones) no matter what.  While ordinarily the weights will all add up to `num_samples,` this is not possible when `num_samples == math.inf`, so the weights instead add up to 1 in this special case.

Otherwise, this is the first step in preparation for my PR that will allow both sampled and exact values to be returned together -- so it's not all or nothing (#190).

Why does a float as `num_samples` make sense in general?  There is this special threshold given by `1 / num_samples`, and this change allows tweaking this threshold arbitrarily.