### PR TITLE
Improve the API reference docs within the utils directory

### DIFF
--- a/circuit_knitting_toolbox/utils/__init__.py
+++ b/circuit_knitting_toolbox/utils/__init__.py
@@ -12,18 +12,14 @@
 """
 Utility functions.
 
-.. autosummary::
-   :toctree: ../stubs/
-   :nosignatures:
-
-   bitwise
-   conversion
-   iteration
-   metrics
-   observable_grouping
-   orbital_reduction.reduce_bitstrings
-   simulation
-   transforms
+.. automodule:: circuit_knitting_toolbox.utils.bitwise
+.. automodule:: circuit_knitting_toolbox.utils.conversion
+.. automodule:: circuit_knitting_toolbox.utils.iteration
+.. automodule:: circuit_knitting_toolbox.utils.metrics
+.. automodule:: circuit_knitting_toolbox.utils.observable_grouping
+.. automodule:: circuit_knitting_toolbox.utils.orbital_reduction
+.. automodule:: circuit_knitting_toolbox.utils.simulation
+.. automodule:: circuit_knitting_toolbox.utils.transforms
 """
 
 from .orbital_reduction import reduce_bitstrings

--- a/circuit_knitting_toolbox/utils/__init__.py
+++ b/circuit_knitting_toolbox/utils/__init__.py
@@ -12,13 +12,52 @@
 """
 Utility functions.
 
+=================================================================
+Bitwise utilities (:mod:`circuit_knitting_toolbox.utils.bitwise`)
+=================================================================
+
 .. automodule:: circuit_knitting_toolbox.utils.bitwise
+
+=============================================================
+Conversion (:mod:`circuit_knitting_toolbox.utils.conversion`)
+=============================================================
+
 .. automodule:: circuit_knitting_toolbox.utils.conversion
+
+=====================================================================
+Iteration utilities (:mod:`circuit_knitting_toolbox.utils.iteration`)
+=====================================================================
+
 .. automodule:: circuit_knitting_toolbox.utils.iteration
+
+=======================================================
+Metrics (:mod:`circuit_knitting_toolbox.utils.metrics`)
+=======================================================
+
 .. automodule:: circuit_knitting_toolbox.utils.metrics
+
+===============================================================================
+Observable grouping (:mod:`circuit_knitting_toolbox.utils.observable_grouping`)
+===============================================================================
+
 .. automodule:: circuit_knitting_toolbox.utils.observable_grouping
+
+===========================================================================
+Orbital reduction (:mod:`circuit_knitting_toolbox.utils.orbital_reduction`)
+===========================================================================
+
 .. automodule:: circuit_knitting_toolbox.utils.orbital_reduction
+
+=============================================================
+Simulation (:mod:`circuit_knitting_toolbox.utils.simulation`)
+=============================================================
+
 .. automodule:: circuit_knitting_toolbox.utils.simulation
+
+=============================================================
+Transforms (:mod:`circuit_knitting_toolbox.utils.transforms`)
+=============================================================
+
 .. automodule:: circuit_knitting_toolbox.utils.transforms
 """
 

--- a/circuit_knitting_toolbox/utils/__init__.py
+++ b/circuit_knitting_toolbox/utils/__init__.py
@@ -16,9 +16,14 @@ Utility functions.
    :toctree: ../stubs/
    :nosignatures:
 
+   bitwise
    conversion
+   iteration
    metrics
+   observable_grouping
    orbital_reduction.reduce_bitstrings
+   simulation
+   transforms
 """
 
 from .orbital_reduction import reduce_bitstrings

--- a/circuit_knitting_toolbox/utils/bitwise.py
+++ b/circuit_knitting_toolbox/utils/bitwise.py
@@ -9,7 +9,20 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Bitwise utilities."""
+"""
+=================================================================
+Bitwise utilities (:mod:`circuit_knitting_toolbox.utils.bitwise`)
+=================================================================
+
+Bitwise utilities.
+
+.. currentmodule:: circuit_knitting_toolbox.utils.bitwise
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   bit_count
+"""
 
 if hasattr(0, "bit_count"):
 

--- a/circuit_knitting_toolbox/utils/bitwise.py
+++ b/circuit_knitting_toolbox/utils/bitwise.py
@@ -10,10 +10,6 @@
 # that they have been altered from the originals.
 
 """
-=================================================================
-Bitwise utilities (:mod:`circuit_knitting_toolbox.utils.bitwise`)
-=================================================================
-
 Bitwise utilities.
 
 .. currentmodule:: circuit_knitting_toolbox.utils.bitwise

--- a/circuit_knitting_toolbox/utils/conversion.py
+++ b/circuit_knitting_toolbox/utils/conversion.py
@@ -10,10 +10,6 @@
 # that they have been altered from the originals.
 
 """
-=============================================================
-Conversion (:mod:`circuit_knitting_toolbox.utils.conversion`)
-=============================================================
-
 Code for converting types of distributions.
 
 .. currentmodule:: circuit_knitting_toolbox.utils.conversion

--- a/circuit_knitting_toolbox/utils/conversion.py
+++ b/circuit_knitting_toolbox/utils/conversion.py
@@ -9,7 +9,23 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Code for converting types of distributions."""
+"""
+=============================================================
+Conversion (:mod:`circuit_knitting_toolbox.utils.conversion`)
+=============================================================
+
+Code for converting types of distributions.
+
+.. currentmodule:: circuit_knitting_toolbox.utils.conversion
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   quasi_to_real
+   nearest_probability_distribution
+   naive_probability_distribution
+   dict_to_array
+"""
 
 import numpy as np
 
@@ -35,7 +51,7 @@ def quasi_to_real(quasiprobability, mode):
 
 def nearest_probability_distribution(quasiprobability):
     """
-    Convert quasiprobability dist to the nearest probability dist.
+    Convert quasiprobability distribution to the nearest probability distribution.
 
     Takes a quasiprobability distribution and maps
     it to the closest probability distribution as defined by

--- a/circuit_knitting_toolbox/utils/iteration.py
+++ b/circuit_knitting_toolbox/utils/iteration.py
@@ -9,7 +9,21 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Iteration utilities."""
+"""
+=====================================================================
+Iteration utilities (:mod:`circuit_knitting_toolbox.utils.iteration`)
+=====================================================================
+
+Iteration utilities.
+
+.. currentmodule:: circuit_knitting_toolbox.utils.iteration
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   unique_by_id
+   unique_by_eq
+"""
 
 import sys
 from collections.abc import Iterable, ValuesView

--- a/circuit_knitting_toolbox/utils/iteration.py
+++ b/circuit_knitting_toolbox/utils/iteration.py
@@ -10,10 +10,6 @@
 # that they have been altered from the originals.
 
 """
-=====================================================================
-Iteration utilities (:mod:`circuit_knitting_toolbox.utils.iteration`)
-=====================================================================
-
 Iteration utilities.
 
 .. currentmodule:: circuit_knitting_toolbox.utils.iteration

--- a/circuit_knitting_toolbox/utils/metrics.py
+++ b/circuit_knitting_toolbox/utils/metrics.py
@@ -10,10 +10,6 @@
 # that they have been altered from the originals.
 
 """
-=======================================================
-Metrics (:mod:`circuit_knitting_toolbox.utils.metrics`)
-=======================================================
-
 Functions for comparing array distances.
 
 .. currentmodule:: circuit_knitting_toolbox.utils.metrics

--- a/circuit_knitting_toolbox/utils/metrics.py
+++ b/circuit_knitting_toolbox/utils/metrics.py
@@ -9,7 +9,24 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Functions for comparing array distances."""
+"""
+=======================================================
+Metrics (:mod:`circuit_knitting_toolbox.utils.metrics`)
+=======================================================
+
+Functions for comparing array distances.
+
+.. currentmodule:: circuit_knitting_toolbox.utils.metrics
+
+.. autosummary::
+   :toctree: ../stubs
+
+   chi2_distance
+   MSE
+   MAPE
+   cross_entropy
+   HOP
+"""
 
 import copy
 

--- a/circuit_knitting_toolbox/utils/metrics.py
+++ b/circuit_knitting_toolbox/utils/metrics.py
@@ -175,7 +175,7 @@ def MAPE(target, obs):  # noqa: D301
 
 def cross_entropy(target, obs):  # noqa: D301
     r"""
-    Compue the cross entropy between two distributions.
+    Compute the cross entropy between two distributions.
 
     The cross entropy is a measure of the difference between two probability
     distributions, defined via:
@@ -225,7 +225,7 @@ def cross_entropy(target, obs):  # noqa: D301
 
 def HOP(target, obs):
     """
-    Compue the Heavy Output Probability (HOP).
+    Compute the Heavy Output Probability (HOP).
 
     The HOP is an important metric for quantum volume experiments and is defined at the
     probability that one measures a bitstring above the median target probability.

--- a/circuit_knitting_toolbox/utils/observable_grouping.py
+++ b/circuit_knitting_toolbox/utils/observable_grouping.py
@@ -10,10 +10,6 @@
 # that they have been altered from the originals.
 
 """
-===============================================================================
-Observable grouping (:mod:`circuit_knitting_toolbox.utils.observable_grouping`)
-===============================================================================
-
 Module for conducting Pauli observable grouping.
 
 .. currentmodule:: circuit_knitting_toolbox.utils.observable_grouping

--- a/circuit_knitting_toolbox/utils/observable_grouping.py
+++ b/circuit_knitting_toolbox/utils/observable_grouping.py
@@ -9,7 +9,22 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Module for conducting Pauli observable grouping."""
+"""
+===============================================================================
+Observable grouping (:mod:`circuit_knitting_toolbox.utils.observable_grouping`)
+===============================================================================
+
+Module for conducting Pauli observable grouping.
+
+.. currentmodule:: circuit_knitting_toolbox.utils.observable_grouping
+
+.. autosummary::
+   :toctree: ../stubs
+
+   observables_restricted_to_subsystem
+   CommutingObservableGroup
+   ObservableCollection
+"""
 
 from __future__ import annotations
 

--- a/circuit_knitting_toolbox/utils/orbital_reduction.py
+++ b/circuit_knitting_toolbox/utils/orbital_reduction.py
@@ -9,7 +9,20 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Helper functions for reducing orbitals."""
+"""
+===========================================================================
+Orbital reduction (:mod:`circuit_knitting_toolbox.utils.orbital_reduction`)
+===========================================================================
+
+Helper functions for reducing orbitals.
+
+.. currentmodule:: circuit_knitting_toolbox.utils.orbital_reduction
+
+.. autosummary::
+   :toctree: ../stubs
+
+   reduce_bitstrings
+"""
 
 import numpy as np
 

--- a/circuit_knitting_toolbox/utils/orbital_reduction.py
+++ b/circuit_knitting_toolbox/utils/orbital_reduction.py
@@ -10,10 +10,6 @@
 # that they have been altered from the originals.
 
 """
-===========================================================================
-Orbital reduction (:mod:`circuit_knitting_toolbox.utils.orbital_reduction`)
-===========================================================================
-
 Helper functions for reducing orbitals.
 
 .. currentmodule:: circuit_knitting_toolbox.utils.orbital_reduction

--- a/circuit_knitting_toolbox/utils/simulation.py
+++ b/circuit_knitting_toolbox/utils/simulation.py
@@ -10,10 +10,6 @@
 # that they have been altered from the originals.
 
 """
-=============================================================
-Simulation (:mod:`circuit_knitting_toolbox.utils.simulation`)
-=============================================================
-
 Simulation of precise measurement outcome probabilities.
 
 .. currentmodule:: circuit_knitting_toolbox.utils.simulation

--- a/circuit_knitting_toolbox/utils/simulation.py
+++ b/circuit_knitting_toolbox/utils/simulation.py
@@ -9,7 +9,21 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Simulation of precise measurement outcome probabilities."""
+"""
+=============================================================
+Simulation (:mod:`circuit_knitting_toolbox.utils.simulation`)
+=============================================================
+
+Simulation of precise measurement outcome probabilities.
+
+.. currentmodule:: circuit_knitting_toolbox.utils.simulation
+
+.. autosummary::
+   :toctree: ../stubs
+
+   simulate_statevector_outcomes
+   ExactSampler
+"""
 from __future__ import annotations
 
 from collections import defaultdict

--- a/circuit_knitting_toolbox/utils/transforms.py
+++ b/circuit_knitting_toolbox/utils/transforms.py
@@ -9,12 +9,27 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Functions for manipulating quantum circuit objects."""
+"""
+=============================================================
+Transforms (:mod:`circuit_knitting_toolbox.utils.transforms`)
+=============================================================
+
+Functions for manipulating quantum circuits.
+
+.. currentmodule:: circuit_knitting_toolbox.utils.transforms
+
+.. autosummary::
+   :toctree: ../stubs
+
+   separate_circuit
+   SeparatedCircuits
+"""
 from __future__ import annotations
 
 from uuid import uuid4, UUID
-from collections import namedtuple, defaultdict
+from collections import defaultdict
 from collections.abc import Sequence, Iterable, Hashable, MutableMapping
+from typing import NamedTuple
 
 from rustworkx import PyGraph, connected_components
 from qiskit.circuit import (
@@ -26,7 +41,11 @@ from qiskit.circuit import (
 )
 
 
-SeparatedCircuits = namedtuple("SeparatedCircuits", ["subcircuits", "qubit_map"])
+class SeparatedCircuits(NamedTuple):
+    """Named tuple for result of :class:`separate_circuit`."""
+
+    subcircuits: dict[Hashable, QuantumCircuit]
+    qubit_map: list[tuple[Hashable, int]]
 
 
 def separate_circuit(

--- a/circuit_knitting_toolbox/utils/transforms.py
+++ b/circuit_knitting_toolbox/utils/transforms.py
@@ -10,10 +10,6 @@
 # that they have been altered from the originals.
 
 """
-=============================================================
-Transforms (:mod:`circuit_knitting_toolbox.utils.transforms`)
-=============================================================
-
 Functions for manipulating quantum circuits.
 
 .. currentmodule:: circuit_knitting_toolbox.utils.transforms

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ extras =
 commands =
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "stubs", ignore_errors=True)'
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "_build" / "html" / ".doctrees", ignore_errors=True)'
-  sphinx-build -b html -W -T --keep-going {posargs} docs/ docs/_build/html
+  sphinx-build -j auto -b html -W -T --keep-going {posargs} docs/ docs/_build/html
 
 [pytest]
 addopts = --doctest-modules -rs --durations=10


### PR DESCRIPTION
This improves the API docs within the utils, by showing each utility module separately on the utils page.  I've also enabled Sphinx parallel build to save time (45 seconds, down from 75 seconds before).