### PR TITLE
Reorganize optional dependencies, and use randomly in notebook tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,19 @@ pyscf = [
     "pyscf>=2.0.1; sys_platform != 'win32'",
 ]
 dev = [
-    "circuit-knitting-toolbox[test,lint]",
-    "nbmake",
+    "circuit-knitting-toolbox[test,nbtest,lint]",
 ]
-test = [
-    "ddt>=1.4.4",
-    "circuit-knitting-toolbox[pyscf]",
+basetest = [
     "pytest>=6.2.5",
     "pytest-randomly>=1.2.0",
+]
+test = [
+    "circuit-knitting-toolbox[basetest,pyscf]",
+    "ddt>=1.4.4",
+]
+nbtest = [
+    "circuit-knitting-toolbox[basetest]",
+    "nbmake>=1.3.4"
 ]
 style = [
     "autoflake==2.1.1",

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,8 @@ commands =
   reno lint
 
 [testenv:{,py38-,py39-,py310-,py311-}notebook]
-deps =
-  nbmake
 extras =
+  nbtest
   notebook-dependencies
 commands =
   pytest --nbmake --nbmake-timeout=3000 {posargs} docs/


### PR DESCRIPTION
I noticed that our notebook tests don't use `pytest-randomly`, so any given run is not reproducible.  While addressing this, I also re-organized the "optional" dependencies a bit.