### PR TITLE
Remove `ThreadPool` in qpd cutting evaluation code

### DIFF
--- a/circuit_knitting_toolbox/circuit_cutting/cutting_evaluation.py
+++ b/circuit_knitting_toolbox/circuit_cutting/cutting_evaluation.py
@@ -139,10 +139,9 @@ def execute_experiments(
     # Wait for the results
     for iterator in iters:
         for _ in iterator:
-            pass
+            pass  # pragma: no cover
     # Collect the results
     quasi_dists_by_partition = [gen.value for gen in generators]
-    print(f"quasi_dists_by_partition: {quasi_dists_by_partition}")
 
     # Reformat the counts to match the shape of the input before returning
     num_unique_samples = len(subexperiments)


### PR DESCRIPTION
This seems to have been leading to deadlock, perhaps because qiskit-ibm-runtime may not be thread safe.

I've adjusted it to submit all the jobs, then collect the results, all on the same thread.

It's a bit obscure use of generators, but it works, and we can refactor later.