### PR TITLE
Update installation instructions

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -107,6 +107,13 @@ Adjust the options below to suit your needs.
     
     pip install tox notebook -e '.[notebook-dependencies,dev,pyscf,cplex]'
 
+If you installed the notebook dependencies, you should be ready to run the notebooks in the docs.
+
+.. code::
+    
+    cd docs/
+    jupyter notebook
+
 
 .. _Option 3:
 
@@ -160,17 +167,6 @@ Jupyter Notebook interface.
 The home directory includes a subdirectory named ``persistent-volume``.
 All work you’d like to save should be placed in this directory, as it is
 the only one that will be saved across different container runs.
-
-
-Running some Examples
-^^^^^^^^^^^^^^^^^^^^^
-From inside the ``circuit-knitting-toolbox`` repository, navigate to the tutorials via the `docs/` directory, open
-a `Jupyter Notebook <https://jupyter.org/install>`__ instance, and start experimenting with CKT!
-
-.. code::
-    
-    cd docs/
-    jupyter notebook
 
 
 .. _Platform Support:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -95,7 +95,7 @@ Next, upgrade pip and enter the repository.
 
 The next step is to install CKT to the virtual environment. If you plan on running the tutorials, install the
 notebook dependencies in order to run all the visualizations in the notebooks.
-If you plan on developing in the repo, you may want to install the dev dependencies.
+If you plan on developing in the repository, you may want to install the ``dev`` dependencies.
 
 Users intending to use the entanglement forging tool should install the ``pyscf`` optional dependency.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -9,6 +9,14 @@ packages. There are three primary ways to do this: :ref:`Option 1`,
 
 Pre-Installation
 ^^^^^^^^^^^^^^^^
+.. note::
+
+    If a user wishes to use the circuit cutting tool to
+    automatically find optimized wire cuts for a circuit too large for
+    the free version of CPLEX, they should acquire a license and install
+    the `full
+    version <https://www.ibm.com/products/ilog-cplex-optimization-studio>`__.
+
 Users with ARM chips and Windows users should consult the
 :ref:`Platform Support` section to determine which installation option
 is appropriate for them. Users who wish to run within a
@@ -34,14 +42,6 @@ Note: If you are using Windows, use the following commands in PowerShell:
     
     python3 -m venv c:\path\to\virtual\environment
     c:\path\to\virtual\environment\Scripts\Activate.ps1
-
-.. note::
-
-    **OPTIONAL** If a user wishes to use the circuit cutting tool to
-    automatically find optimized wire cuts for a circuit too large for
-    the free version of CPLEX, they should acquire a license and install
-    the `full
-    version <https://www.ibm.com/products/ilog-cplex-optimization-studio>`__.
 
 
 .. _Option 1:
@@ -103,7 +103,7 @@ Users intending to use the entanglement forging tool should install the pyscf op
 
 .. code:: sh
     
-    pip install '.[pyscf]'
+    pip install -e '.[pyscf]'
 
 Users intending to use the automatic cut finding functionality in the CutQC package should install the cplex option.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -46,7 +46,7 @@ Note: If you are using Windows, use the following commands in PowerShell:
 
 .. _Option 1:
 
-Option 1: Pip installation
+Option 1: Pip Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Upgrade pip.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -14,7 +14,7 @@ Users with ARM chips and Windows users should consult the
 is appropriate for them. Users who wish to run within a
 containerized environment may skip the pre-installation and move straight
 to :ref:`Option 3`. Otherwise, users who wish to install locally or via PyPI may 
-ollow a few set of common instructions to prepare for installation:
+follow a few set of common instructions to prepare for installation:
 
 First, create a minimal environment with only Python installed in it. We recommend using `Python virtual environments <https://docs.python.org/3.10/tutorial/venv.html>`__.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -63,17 +63,17 @@ Install the CKT package.
 
     pip install circuit-knitting-toolbox
 
-Users intending to use the automatic cut finding functionality in the CutQC package should install the cplex option.
-
-.. code:: sh
-    
-    pip install 'circuit-knitting-toolbox[cplex]'
-
 Users intending to use the entanglement forging tool should install the pyscf option.
 
 .. code:: sh
     
     pip install 'circuit-knitting-toolbox[pyscf]'
+
+Users intending to use the automatic cut finding functionality in the CutQC package should install the cplex option.
+
+.. code:: sh
+    
+    pip install 'circuit-knitting-toolbox[cplex]'
     
 
 .. _Option 2:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -7,12 +7,13 @@ packages. There are three primary ways to do this: :ref:`Option 1`,
 :ref:`Option 2`, or :ref:`Option 3`.
 
 
-Prerequisites
-^^^^^^^^^^^^^
+Pre-Installation
+^^^^^^^^^^^^^^^^
 Users with ARM chips and Windows users should consult the
 :ref:`Platform Support` section to determine which installation option
 is appropriate for them. Users who wish to run within a
-containerized environment may skip the prerequisites and move to :ref:`Option 3`.
+containerized environment may skip the pre-installation and move straight
+to :ref:`Option 3`.
 
 Users who wish to install locally or via PyPI may follow a few set of
 common instructions to prepare for installation:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -190,6 +190,7 @@ recommend either :ref:`Option 1` or :ref:`Option 2`.
 
 All users on ARM chips, as well as all Windows users, may have to
 use the toolbox within Docker (:ref:`Option 3`), depending on what tools they intend to use.
+  
   - The automatic wire cut search in the ``circuit_cutting`` module depends
     on CPLEX, which is only available on Intel chips and is not yet available
     for Python 3.11.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -66,6 +66,8 @@ Users intending to use the entanglement forging tool should install the ``pyscf`
 
 Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` optional dependency.
 
+Adjust the options below to suit your needs.
+
 .. code:: sh
     
     pip install 'circuit-knitting-toolbox[pyscf,cplex]'
@@ -98,6 +100,8 @@ If you plan on developing in the repo, you may want to install the dev dependenc
 Users intending to use the entanglement forging tool should install the ``pyscf`` option.
 
 Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` option.
+
+Adjust the options below to suit your needs.
 
 .. code:: sh
     
@@ -165,7 +169,7 @@ a `Jupyter Notebook <https://jupyter.org/install>`__ instance, and start experim
 
 .. code::
     
-    cd docs/<circuit_cutting | entanglement_forging>/tutorials
+    cd docs/
     jupyter notebook
 
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -62,7 +62,7 @@ Upgrade pip and install the CKT package.
     pip install --upgrade pip
     pip install circuit-knitting-toolbox
 
-Users intending to use the entanglement forging tool should install the ``pyscf`` option.
+Users intending to use the entanglement forging tool should install the ``pyscf`` optional dependency.
 
 Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` optional dependency.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,62 +1,119 @@
-#########################
-Installation Instructions
-#########################
+Install
+=======
 
-There are three options: installing via pip, installing locally or
-using within a Docker container.
+Let's get started with the Circuit Knitting Toolbox (CKT)! The first
+thing to do is choose how you're going to run and install the
+packages. There are three primary ways to do this: :ref:`Option 1`,
+:ref:`Option 2`, or :ref:`Option 3`.
 
-- If you are using Linux or macOS with an Intel chip (i.e., not the
-  new M1 or M2 chips), everything should work natively, so we
-  recommend the first option.
-- All users on ARM chips, as well as all Windows users, will have to
-  use the toolbox within Docker (the third option) for all features to
-  work as designed.
 
-Specifically, the following features are unavailable on the
-aforementioned platforms:
+Prerequisites
+^^^^^^^^^^^^^
+Users with ARM chips and Windows users should consult the
+:ref:`Platform Support` section to determine which installation option
+is appropriate for them. Users who wish to run within a
+containerized environment may skip the prerequisits and move to :ref:`Option 3`.
 
-- The automatic wire cut search in the circuit cutting module
-  depends on cplex, which is only available on Intel chips and is not
-  yet available for Python 3.11.
-- The entanglement forging notebooks require pyscf, which does not
-  support Windows.
+Users who wish to install locally or via PyPI may follow a few set of
+common instructions to prepare for installation:
+
+Create a minimal environment with only Python installed in it. We recommend using `Python virtual environments <https://docs.python.org/3.10/tutorial/venv.html>`__.
+
+.. code:: sh
+    
+    python3 -m venv /path/to/virtual/environment
+
+Activate your new environment.
+
+.. code:: sh
+    
+    source /path/to/virtual/environment/bin/activate
+
+Note: If you are using Windows, use the following commands in PowerShell:
+
+.. code:: sh
+    
+    python3 -m venv c:\path\to\virtual\environment
+    c:\path\to\virtual\environment\Scripts\Activate.ps1
 
 .. note::
+
     **OPTIONAL** If a user wishes to use the circuit cutting tool to
     automatically find optimized wire cuts for a circuit too large for
     the free version of CPLEX, they should acquire a license and install
     the `full
     version <https://www.ibm.com/products/ilog-cplex-optimization-studio>`__.
 
+
+.. _Option 1:
+
 Option 1: pip installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- The most straightforward way to install the software is to install via pip.
-  Users who want to run entanglement forging should include the pyscf option,
-  and users who want to run the CutQC package should use the cplex option.
+Upgrade pip.
+
+.. code:: sh
+    
+    pip install --upgrade pip
+
+Install the CKT package.
 
 .. code:: sh
 
-    pip install circuit-knitting-toolbox[<pyscf, cplex>]
+    pip install circuit-knitting-toolbox
+
+Users intending to use the automatic cut finding functionality in the CutQC package should install the cplex option.
+
+.. code:: sh
     
-Option 2: Local installation
+    pip install 'circuit-knitting-toolbox[cplex]'
+
+Users intending to use the entanglement forging tool should install the pyscf option.
+
+.. code:: sh
+    
+    pip install 'circuit-knitting-toolbox[pyscf]'
+    
+
+.. _Option 2:
+
+Option 2: Local Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  Users who wish to develop in the repository, or who do not wish to install via
-   pip, may wish to run off a local installation.
+Clone the CKT repository.
 
 .. code:: sh
 
     git clone git@github.com:Qiskit-Extensions/circuit-knitting-toolbox.git
-    cd circuit-knitting-toolbox
-    python3 -m venv venv
-    source venv/bin/activate
-    pip install --upgrade pip
-    pip install tox notebook -e '.[notebook-dependencies]'
-    jupyter notebook
+    
+Upgrade pip and enter the repository. 
 
--  Navigate to the notebooks in the ``docs/tutorials/`` directory to run the
-   tutorials.
+.. code:: sh
+    
+    pip install --upgrade pip
+    cd circuit-knitting-toolbox
+
+Install CKT from source. Install the notebook dependencies in order to run
+all the visualizations in the tutorial notebooks.
+
+.. code:: sh
+    
+    pip install tox notebook -e '.[notebook-dependencies]'
+
+Users intending to use the entanglement forging tool should install the pyscf option.
+
+.. code:: sh
+    
+    pip install '.[pyscf]'
+
+Users intending to use the automatic cut finding functionality in the CutQC package should install the cplex option.
+
+.. code:: sh
+    
+    pip install -e '.[cplex]'
+
+
+.. _Option 3:
 
 Option 3: Use within Docker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,3 +165,38 @@ Jupyter notebook interface.
 The home directory includes a subdirectory named ``persistent-volume``.
 All work you’d like to save should be placed in this directory, as it is
 the only one that will be saved across different container runs.
+
+
+Running some Examples
+^^^^^^^^^^^^^^^^^^^^^
+From inside the ``circuit_knitting_toolbox`` repository, open a `Jupyter Notebook <https://jupyter.org/install>`__, navigate
+to the tutorials, and open a Jupyter Notebook instance.
+
+.. code::
+    
+    cd docs/<circuit_cutting | entanglement_forging>/tutorials
+    jupyter notebook
+
+
+.. _Platform Support:
+
+Platform Support
+^^^^^^^^^^^^^^^^
+
+Users of Mac M1 or M2 chips and Windows users may have issues running certain components of CKT.
+
+- If you are using Linux or macOS with an Intel chip (i.e., not the
+  new M1 or M2 chips), everything should work natively, so we
+  recommend either :ref:`Option 1` or :ref:`Option 2`.
+- All users on ARM chips, as well as all Windows users, will have to
+  use the toolbox within Docker (:ref:`Option 3`) for all features to
+  work as designed.
+
+Specifically, the following features are unavailable on the
+aforementioned platforms:
+
+- The automatic wire cut search in the circuit cutting module
+  depends on cplex, which is only available on Intel chips and is not
+  yet available for Python 3.11.
+- The entanglement forging tool requires pyscf, which does not
+  support Windows.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -21,7 +21,7 @@ CutQC and entanglement forging users should consult the
 :ref:`Platform Support` section to determine which installation option
 is appropriate for them. Users who wish to run within a
 containerized environment may skip the pre-installation and move straight
-to :ref:`Option 3`. Otherwise, users who wish to install locally or via PyPI may 
+to :ref:`Option 3`. Otherwise, users who wish to install locally may 
 follow a few set of common instructions to prepare a Python environment for
 installation of CKT:
 
@@ -54,56 +54,48 @@ Upgrade pip and install the CKT package.
 
 .. code:: sh
 
-    pip install --upgrade pip circuit-knitting-toolbox
+    pip install --upgrade pip
+    pip install circuit-knitting-toolbox
 
 Users intending to use the entanglement forging tool should install the ``pyscf`` option.
-
-.. code:: sh
-    
-    pip install 'circuit-knitting-toolbox[pyscf]'
 
 Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` option.
 
 .. code:: sh
     
-    pip install 'circuit-knitting-toolbox[cplex]'
-    
+    pip install 'circuit-knitting-toolbox[pyscf,cplex]'
+
 
 .. _Option 2:
 
-Option 2: Local Installation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Option 2: Install from Source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Clone the circuit-knitting-toolbox repository.
+Users who wish to develop in the repository or run the tutorials locally may want to install from source.
+
+In either case, the first step is to clone the CKT repository.
 
 .. code:: sh
 
     git clone git@github.com:Qiskit-Extensions/circuit-knitting-toolbox.git
     
-Upgrade pip and enter the repository. 
+Next, upgrade pip and enter the repository. 
 
 .. code:: sh
     
     pip install --upgrade pip && cd circuit-knitting-toolbox
 
-Install CKT from source. Install the notebook dependencies in order to run
-all the visualizations in the tutorial notebooks.
-
-.. code:: sh
-    
-    pip install tox notebook -e '.[notebook-dependencies]'
+Install CKT from source. If you plan on running the tutorials, install the
+notebook dependencies in order to run all the visualizations in the notebooks.
+If you plan on developing in the repo, you may want to install the dev dependencies.
 
 Users intending to use the entanglement forging tool should install the ``pyscf`` option.
-
-.. code:: sh
-    
-    pip install -e '.[pyscf]'
 
 Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` option.
 
 .. code:: sh
     
-    pip install -e '.[cplex]'
+    pip install tox notebook -e '.[notebook-dependencies,dev,pyscf,cplex]'
 
 
 .. _Option 3:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -46,7 +46,7 @@ Note: If you are using Windows, use the following commands in PowerShell:
 
 .. _Option 1:
 
-Option 1: pip installation
+Option 1: Pip installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Upgrade pip.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -162,8 +162,8 @@ the only one that will be saved across different container runs.
 
 Running some Examples
 ^^^^^^^^^^^^^^^^^^^^^
-From inside the ``circuit_knitting_toolbox`` repository, open a `Jupyter Notebook <https://jupyter.org/install>`__, navigate
-to the tutorials, open a Jupyter Notebook instance, and start experimenting with CKT!
+From inside the ``circuit_knitting_toolbox`` repository, navigate to the tutorials, open
+a `Jupyter Notebook <https://jupyter.org/install>`__ instance, and start experimenting with CKT!
 
 .. code::
     

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -11,13 +11,13 @@ Pre-Installation
 ^^^^^^^^^^^^^^^^
 .. note::
 
-    If a user wishes to use the circuit cutting tool to
+    If a user wishes to use the circuit cutting toolbox to
     automatically find optimized wire cuts for a circuit too large for
     the free version of CPLEX, they should acquire a license and install
     the `full
     version <https://www.ibm.com/products/ilog-cplex-optimization-studio>`__.
 
-Users with ARM chips and Windows users should consult the
+CutQC and entanglement forging users should consult the
 :ref:`Platform Support` section to determine which installation option
 is appropriate for them. Users who wish to run within a
 containerized environment may skip the pre-installation and move straight

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -2,14 +2,14 @@
 Installation Instructions
 #########################
 
-There are two options: installing locally or using within a Docker
-container.
+There are three options: installing via pip, installing locally or
+using within a Docker container.
 
 - If you are using Linux or macOS with an Intel chip (i.e., not the
   new M1 or M2 chips), everything should work natively, so we
   recommend the first option.
 - All users on ARM chips, as well as all Windows users, will have to
-  use the toolbox within Docker (the second option) for all features to
+  use the toolbox within Docker (the third option) for all features to
   work as designed.
 
 Specifically, the following features are unavailable on the
@@ -21,16 +21,29 @@ aforementioned platforms:
 - The entanglement forging notebooks require pyscf, which does not
   support Windows.
 
-Option 1: Local installation
+.. note::
+    **OPTIONAL** If a user wishes to use the circuit cutting tool to
+    automatically find optimized wire cuts for a circuit too large for
+    the free version of CPLEX, they should acquire a license and install
+    the `full
+    version <https://www.ibm.com/products/ilog-cplex-optimization-studio>`__.
+
+Option 1: pip installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- The most straightforward way to install the software is to install via pip.
+  Users who want to run entanglement forging should include the pyscf option,
+  and users who want to run the CutQC package should use the cplex option.
+
+.. code:: sh
+
+    pip install circuit-knitting-toolbox[<pyscf, cplex>]
+    
+Option 2: Local installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **OPTIONAL** If a user wishes to use the circuit cutting tool to
-   automatically find optimized wire cuts for a circuit too large for
-   the free version of CPLEX, they should acquire a license and install
-   the `full
-   version <https://www.ibm.com/products/ilog-cplex-optimization-studio>`__.
-
--  Enter a Python environment and install the software
+-  Users who wish to develop in the repository, or who do not wish to install via
+   pip, may wish to run off a local installation.
 
 .. code:: sh
 
@@ -45,7 +58,7 @@ Option 1: Local installation
 -  Navigate to the notebooks in the ``docs/tutorials/`` directory to run the
    tutorials.
 
-Option 2: Use within Docker
+Option 3: Use within Docker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We have provided a `Dockerfile <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/main/Dockerfile>`__, which can be used to

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,7 +1,7 @@
 Installation Instructions
 =========================
 
-Let's see how to install Circuit Knitting Toolbox (CKT). The first
+Let's see how to install the Circuit Knitting Toolbox (CKT). The first
 thing to do is choose how you're going to run and install the
 packages. There are three primary ways to do this: :ref:`Option 1`,
 :ref:`Option 2`, or :ref:`Option 3`.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -3,12 +3,18 @@ Installation Instructions
 
 Let's see how to install the Circuit Knitting Toolbox (CKT). The first
 thing to do is choose how you're going to run and install the
-packages. There are three primary ways to do this: :ref:`Option 1`,
-:ref:`Option 2`, or :ref:`Option 3`.
+packages. There are three primary ways to do this:
 
+- :ref:`Option 1`
+- :ref:`Option 2`
+- :ref:`Option 3`
 
-Pre-Installation
-^^^^^^^^^^^^^^^^
+CutQC and entanglement forging users should consult the
+:ref:`Platform Support` section to determine which installation option
+is appropriate for them. Users who wish to run within a
+containerized environment may skip the pre-installation and move straight
+to :ref:`Option 3`.
+
 .. note::
 
     If a user wishes to use the circuit cutting toolbox to
@@ -17,11 +23,10 @@ Pre-Installation
     the `full
     version <https://www.ibm.com/products/ilog-cplex-optimization-studio>`__.
 
-CutQC and entanglement forging users should consult the
-:ref:`Platform Support` section to determine which installation option
-is appropriate for them. Users who wish to run within a
-containerized environment may skip the pre-installation and move straight
-to :ref:`Option 3`. Otherwise, users who wish to install locally may 
+Pre-Installation
+^^^^^^^^^^^^^^^^
+
+Users who wish to install locally (using either :ref:`Option 1` or :ref:`Option 2`) may 
 follow a few set of common instructions to prepare a Python environment for
 installation of CKT:
 
@@ -59,7 +64,7 @@ Upgrade pip and install the CKT package.
 
 Users intending to use the entanglement forging tool should install the ``pyscf`` option.
 
-Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` option.
+Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` optional dependency.
 
 .. code:: sh
     
@@ -83,9 +88,10 @@ Next, upgrade pip and enter the repository.
 
 .. code:: sh
     
-    pip install --upgrade pip && cd circuit-knitting-toolbox
+    pip install --upgrade pip
+    cd circuit-knitting-toolbox
 
-Install CKT from source. If you plan on running the tutorials, install the
+The next step is to install CKT to the virtual environment. If you plan on running the tutorials, install the
 notebook dependencies in order to run all the visualizations in the notebooks.
 If you plan on developing in the repo, you may want to install the dev dependencies.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -189,15 +189,9 @@ Users of Mac M1 or M2 chips and Windows users may have issues running certain co
 - If you are using Linux or macOS with an Intel chip (i.e., not the
   new M1 or M2 chips), everything should work natively, so we
   recommend either :ref:`Option 1` or :ref:`Option 2`.
-- All users on ARM chips, as well as all Windows users, will have to
-  use the toolbox within Docker (:ref:`Option 3`) for all features to
-  work as designed.
-
-Specifically, the following features are unavailable on the
-aforementioned platforms:
-
-- The automatic wire cut search in the circuit cutting module
-  depends on cplex, which is only available on Intel chips and is not
-  yet available for Python 3.11.
-- The entanglement forging tool requires pyscf, which does not
-  support Windows.
+- All users on ARM chips, as well as all Windows users, may have to
+  use the toolbox within Docker (:ref:`Option 3`), depending on what tools they intend to use.
+    - The automatic wire cut search in the ``circuit_cutting`` module depends
+      on cplex, which is only available on Intel chips and is not yet available
+      for Python 3.11.
+    - The entanglement forging tool requires pyscf, which does not support Windows.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -59,7 +59,7 @@ Upgrade pip and install the CKT package.
 
 .. code:: sh
 
-    pip install --upgrade pip && pip install circuit-knitting-toolbox
+    pip install --upgrade pip circuit-knitting-toolbox
 
 Users intending to use the entanglement forging tool should install the ``pyscf`` option.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -50,12 +50,6 @@ Note: If you are using Windows, use the following commands in PowerShell:
 Option 1: Pip Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Upgrade pip.
-
-.. code:: sh
-    
-    pip install --upgrade pip
-
 Upgrade pip and install the CKT package.
 
 .. code:: sh

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -61,13 +61,13 @@ Install the CKT package.
 
     pip install circuit-knitting-toolbox
 
-Users intending to use the entanglement forging tool should install the pyscf option.
+Users intending to use the entanglement forging tool should install the ``pyscf`` option.
 
 .. code:: sh
     
     pip install 'circuit-knitting-toolbox[pyscf]'
 
-Users intending to use the automatic cut finding functionality in the CutQC package should install the cplex option.
+Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` option.
 
 .. code:: sh
     
@@ -99,13 +99,13 @@ all the visualizations in the tutorial notebooks.
     
     pip install tox notebook -e '.[notebook-dependencies]'
 
-Users intending to use the entanglement forging tool should install the pyscf option.
+Users intending to use the entanglement forging tool should install the ``pyscf`` option.
 
 .. code:: sh
     
     pip install -e '.[pyscf]'
 
-Users intending to use the automatic cut finding functionality in the CutQC package should install the cplex option.
+Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` option.
 
 .. code:: sh
     
@@ -184,12 +184,13 @@ Platform Support
 
 Users of Mac M1 or M2 chips and Windows users may have issues running certain components of CKT.
 
-- If you are using Linux or macOS with an Intel chip (i.e., not the
-  new M1 or M2 chips), everything should work natively, so we
-  recommend either :ref:`Option 1` or :ref:`Option 2`.
-- All users on ARM chips, as well as all Windows users, may have to
-  use the toolbox within Docker (:ref:`Option 3`), depending on what tools they intend to use.
-    - The automatic wire cut search in the ``circuit_cutting`` module depends
-      on cplex, which is only available on Intel chips and is not yet available
-      for Python 3.11.
-    - The entanglement forging tool requires pyscf, which does not support Windows.
+If you are using Linux or macOS with an Intel chip (i.e., not the
+new M1 or M2 chips), everything should work natively, so we
+recommend either :ref:`Option 1` or :ref:`Option 2`.
+
+All users on ARM chips, as well as all Windows users, may have to
+use the toolbox within Docker (:ref:`Option 3`), depending on what tools they intend to use.
+  - The automatic wire cut search in the ``circuit_cutting`` module depends
+    on CPLEX, which is only available on Intel chips and is not yet available
+    for Python 3.11.
+  - The entanglement forging tool requires PySCF, which does not support Windows.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -185,7 +185,7 @@ recommend either :ref:`Option 1` or :ref:`Option 2`.
 All users on ARM chips, as well as all Windows users, may have to
 use the toolbox within Docker (:ref:`Option 3`), depending on what tools they intend to use.
   
-  - The automatic wire cut search in the ``circuit_cutting`` module depends
+  - The automatic wire cut search in the ``cutqc`` package depends
     on CPLEX, which is only available on Intel chips and is not yet available
     for Python 3.11.
   - The entanglement forging tool requires PySCF, which does not support Windows.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -74,7 +74,7 @@ Users intending to use the automatic cut finding functionality in the CutQC pack
 Option 2: Local Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Clone the CKT repository.
+Clone the circuit-knitting-toolbox repository.
 
 .. code:: sh
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,5 +1,5 @@
-Install
-=======
+Installation Instructions
+=========================
 
 Let's get started with the Circuit Knitting Toolbox (CKT)! The first
 thing to do is choose how you're going to run and install the

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -18,7 +18,7 @@ to :ref:`Option 3`.
 Users who wish to install locally or via PyPI may follow a few set of
 common instructions to prepare for installation:
 
-Create a minimal environment with only Python installed in it. We recommend using `Python virtual environments <https://docs.python.org/3.10/tutorial/venv.html>`__.
+First, create a minimal environment with only Python installed in it. We recommend using `Python virtual environments <https://docs.python.org/3.10/tutorial/venv.html>`__.
 
 .. code:: sh
     

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -55,11 +55,11 @@ Upgrade pip.
     
     pip install --upgrade pip
 
-Install the CKT package.
+Upgrade pip and install the CKT package.
 
 .. code:: sh
 
-    pip install circuit-knitting-toolbox
+    pip install --upgrade pip && pip install circuit-knitting-toolbox
 
 Users intending to use the entanglement forging tool should install the ``pyscf`` option.
 
@@ -89,8 +89,7 @@ Upgrade pip and enter the repository.
 
 .. code:: sh
     
-    pip install --upgrade pip
-    cd circuit-knitting-toolbox
+    pip install --upgrade pip && cd circuit-knitting-toolbox
 
 Install CKT from source. Install the notebook dependencies in order to run
 all the visualizations in the tutorial notebooks.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -26,7 +26,7 @@ to :ref:`Option 3`.
 Pre-Installation
 ^^^^^^^^^^^^^^^^
 
-Users who wish to install locally (using either :ref:`Option 1` or :ref:`Option 2`) may 
+Users who wish to install locally (using either :ref:`Option 1` or :ref:`Option 2`) are encouraged to
 follow a brief set of common instructions to prepare a Python environment for
 installation of CKT:
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -107,7 +107,7 @@ Adjust the options below to suit your needs.
     
     pip install tox notebook -e '.[notebook-dependencies,dev,pyscf,cplex]'
 
-If you installed the notebook dependencies, you should be ready to run the notebooks in the docs.
+If you installed the notebook dependencies, you can get started with CKT by running the notebooks in the docs.
 
 .. code::
     

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -161,7 +161,7 @@ Once the container is running, you should see a message like this:
 
 Locate the *last* URL in your terminal (the one that includes
 ``127.0.0.1``), and navigate to that URL in a web browser to access the
-Jupyter notebook interface.
+Jupyter Notebook interface.
 
 The home directory includes a subdirectory named ``persistent-volume``.
 All work you’d like to save should be placed in this directory, as it is

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -13,10 +13,8 @@ Users with ARM chips and Windows users should consult the
 :ref:`Platform Support` section to determine which installation option
 is appropriate for them. Users who wish to run within a
 containerized environment may skip the pre-installation and move straight
-to :ref:`Option 3`.
-
-Users who wish to install locally or via PyPI may follow a few set of
-common instructions to prepare for installation:
+to :ref:`Option 3`. Otherwise, users who wish to install locally or via PyPI may 
+ollow a few set of common instructions to prepare for installation:
 
 First, create a minimal environment with only Python installed in it. We recommend using `Python virtual environments <https://docs.python.org/3.10/tutorial/venv.html>`__.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,7 +1,7 @@
 Installation Instructions
 =========================
 
-Let's get started with the Circuit Knitting Toolbox (CKT)! The first
+Let's see how to install Circuit Knitting Toolbox (CKT). The first
 thing to do is choose how you're going to run and install the
 packages. There are three primary ways to do this: :ref:`Option 1`,
 :ref:`Option 2`, or :ref:`Option 3`.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -99,7 +99,7 @@ If you plan on developing in the repo, you may want to install the dev dependenc
 
 Users intending to use the entanglement forging tool should install the ``pyscf`` option.
 
-Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` option.
+Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` optional dependency.
 
 Adjust the options below to suit your needs.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -162,7 +162,7 @@ the only one that will be saved across different container runs.
 
 Running some Examples
 ^^^^^^^^^^^^^^^^^^^^^
-From inside the ``circuit_knitting_toolbox`` repository, navigate to the tutorials, open
+From inside the ``circuit-knitting-toolbox`` repository, navigate to the tutorials via the `docs/` directory, open
 a `Jupyter Notebook <https://jupyter.org/install>`__ instance, and start experimenting with CKT!
 
 .. code::

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -163,7 +163,7 @@ the only one that will be saved across different container runs.
 Running some Examples
 ^^^^^^^^^^^^^^^^^^^^^
 From inside the ``circuit_knitting_toolbox`` repository, open a `Jupyter Notebook <https://jupyter.org/install>`__, navigate
-to the tutorials, and open a Jupyter Notebook instance.
+to the tutorials, open a Jupyter Notebook instance, and start experimenting with CKT!
 
 .. code::
     

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ Prerequisites
 Users with ARM chips and Windows users should consult the
 :ref:`Platform Support` section to determine which installation option
 is appropriate for them. Users who wish to run within a
-containerized environment may skip the prerequisits and move to :ref:`Option 3`.
+containerized environment may skip the prerequisites and move to :ref:`Option 3`.
 
 Users who wish to install locally or via PyPI may follow a few set of
 common instructions to prepare for installation:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -27,7 +27,7 @@ Pre-Installation
 ^^^^^^^^^^^^^^^^
 
 Users who wish to install locally (using either :ref:`Option 1` or :ref:`Option 2`) may 
-follow a few set of common instructions to prepare a Python environment for
+follow a brief set of common instructions to prepare a Python environment for
 installation of CKT:
 
 First, create a minimal environment with only Python installed in it. We recommend using `Python virtual environments <https://docs.python.org/3.10/tutorial/venv.html>`__.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -22,7 +22,8 @@ Users with ARM chips and Windows users should consult the
 is appropriate for them. Users who wish to run within a
 containerized environment may skip the pre-installation and move straight
 to :ref:`Option 3`. Otherwise, users who wish to install locally or via PyPI may 
-follow a few set of common instructions to prepare for installation:
+follow a few set of common instructions to prepare a Python environment for
+installation of CKT:
 
 First, create a minimal environment with only Python installed in it. We recommend using `Python virtual environments <https://docs.python.org/3.10/tutorial/venv.html>`__.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -97,7 +97,7 @@ The next step is to install CKT to the virtual environment. If you plan on runni
 notebook dependencies in order to run all the visualizations in the notebooks.
 If you plan on developing in the repo, you may want to install the dev dependencies.
 
-Users intending to use the entanglement forging tool should install the ``pyscf`` option.
+Users intending to use the entanglement forging tool should install the ``pyscf`` optional dependency.
 
 Users intending to use the automatic cut finding functionality in the CutQC package should install the ``cplex`` optional dependency.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -44,7 +44,7 @@ Activate your new environment.
 
 Note: If you are using Windows, use the following commands in PowerShell:
 
-.. code:: sh
+.. code:: pwsh
     
     python3 -m venv c:\path\to\virtual\environment
     c:\path\to\virtual\environment\Scripts\Activate.ps1


### PR DESCRIPTION
The installation instructions were thorough and correct, but they needed a facelift, and they needed the PyPI installation added as an option.

I lightly borrowed from the [Qiskit installation instructions](https://qiskit.org/documentation/getting_started.html) for language and flow.