### PR TITLE
Remove captures from tutorials

### DIFF
--- a/docs/circuit_cutting/tutorials/gate_cutting_to_reduce_circuit_depth.ipynb
+++ b/docs/circuit_cutting/tutorials/gate_cutting_to_reduce_circuit_depth.ipynb
@@ -299,8 +299,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "\n",
     "# Keep in mind, Terra Sampler does not support mid-circuit measurements at all,\n",
     "# and Aer Sampler does not support mid-circuit measurements when shots==None.\n",
     "sampler = Sampler(run_options={\"shots\": 2**12})\n",
@@ -374,10 +372,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Simulated expectation values: [0.11126709, 0.46905518, -0.12823486, 0.29907227, 0.12219238, 0.14117432]\n",
+      "Simulated expectation values: [0.14038086, 0.44476318, -0.09191895, 0.27740479, 0.09344482, 0.12463379]\n",
       "Exact expectation values: [0.11287228, 0.45443094, -0.09550941, 0.2785706, 0.13660985, 0.13428298]\n",
-      "Errors in estimation: [-0.00160519, 0.01462424, -0.03272545, 0.02050167, -0.01441747, 0.00689134]\n",
-      "Relative errors in estimation: [-0.01422133, 0.03218143, 0.34264111, 0.07359596, -0.10553756, 0.05131951]\n"
+      "Errors in estimation: [0.02750858, -0.00966776, 0.00359047, -0.00116581, -0.04316503, -0.00964919]\n",
+      "Relative errors in estimation: [0.24371418, -0.02127442, -0.03759281, -0.00418497, -0.31597303, -0.07185713]\n"
      ]
     }
    ],

--- a/docs/circuit_cutting/tutorials/gate_cutting_to_reduce_circuit_width.ipynb
+++ b/docs/circuit_cutting/tutorials/gate_cutting_to_reduce_circuit_width.ipynb
@@ -245,8 +245,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "\n",
     "# Keep in mind, Terra Sampler does not support mid-circuit measurements at all,\n",
     "# and Aer Sampler does not support mid-circuit measurements when shots==None.\n",
     "samplers = {\n",
@@ -322,10 +320,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Simulated expectation values: [0.15707213, 0.16719556, 0.30101973, 0.4364444, 0.09293658, 0.72403508]\n",
+      "Simulated expectation values: [0.16709793, 0.18652463, 0.30369848, 0.46279693, 0.08348149, 0.70464808]\n",
       "Exact expectation values: [0.17153613, 0.1815846, 0.30958691, 0.44036036, 0.08173037, 0.70623815]\n",
-      "Errors in estimation: [-0.01446401, -0.01438904, -0.00856719, -0.00391596, 0.01120621, 0.01779693]\n",
-      "Relative errors in estimation: [-0.08432046, -0.07924153, -0.02767296, -0.00889263, 0.13711191, 0.02519962]\n"
+      "Errors in estimation: [-0.00443821, 0.00494003, -0.00588843, 0.02243656, 0.00175112, -0.00159008]\n",
+      "Relative errors in estimation: [-0.02587331, 0.02720511, -0.01902029, 0.05095046, 0.0214256, -0.00225147]\n"
      ]
     }
    ],


### PR DESCRIPTION
I believe upgrading the primitives in the tutorials fixed all the warnings that were generated during `execute_experiments`. Either way, they are gone now, and we no longer need to suppress output in the tutorials :)