### PR TITLE
Tweaks to gate cutting workflow release note

### DIFF
--- a/docs/circuit_cutting/explanation/index.rst
+++ b/docs/circuit_cutting/explanation/index.rst
@@ -1,3 +1,5 @@
+.. _circuit cutting explanation:
+
 ###################################################
 Explanatory material for the circuit cutting module
 ###################################################

--- a/docs/circuit_cutting/tutorials/index.rst
+++ b/docs/circuit_cutting/tutorials/index.rst
@@ -1,3 +1,5 @@
+.. _circuit cutting tutorials:
+
 #########################
 Circuit Cutting Tutorials
 #########################

--- a/releasenotes/notes/gate-cutting-workflow-ebbedbdb1313b258.yaml
+++ b/releasenotes/notes/gate-cutting-workflow-ebbedbdb1313b258.yaml
@@ -2,9 +2,9 @@
 prelude: |
     0.2.0 is centered around the addition of functions which allow for the easy
     implementation of a circuit cutting technique called gate cutting. For more details on circuit cutting, check out our
-    `explanation guide <https://qiskit-extensions.github.io/circuit-knitting-toolbox/circuit_cutting/explanation/index.html>`__.
+    :ref:`explanation guide <circuit cutting explanation>`.
 
-    The foundation of the :mod:`~circuit_knitting_toolbox.circuit cutting` package is the :mod:`circuit_knitting_toolbox.circuit_cutting.qpd`
+    The foundation of the :mod:`~circuit_knitting_toolbox.circuit_cutting` package is the :mod:`circuit_knitting_toolbox.circuit_cutting.qpd`
     sub-package. The :mod:`~circuit_knitting_toolbox.circuit_cutting.qpd` package allows for easy transformation of :class:`~qiskit.QuantumCircuit` gates and wires into elements which may be decomposed to a probabilistic set of basis gates.
     See :class:`~circuit_knitting_toolbox.circuit_cutting.qpd.QPDBasis` and :class:`~circuit_knitting_toolbox.circuit_cutting.qpd.BaseQPDGate` classes for more information.
 
@@ -13,8 +13,8 @@ prelude: |
     circuit knitting techniques, gate cutting can be described as three consecutive stages: *decomposition* of a problem,
     *execution* of many subexperiments, and *reconstruction* of a simulated output of the original problem.
     These steps may be implemented with the :mod:`~circuit_knitting_toolbox.circuit_cutting` package using only a few primary
-    functions, namely, the :func:`partition_problem`, :func:`decompose_gates`, :func:`execute_experiments`, and :func:`reconstruct_expectation_values` functions.
-    Check out the `tutorials <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/tree/main/docs/circuit_cutting/tutorials>`__ for a look at a couple of example circuit cutting workflows.
+    functions, namely, the :func:`.partition_problem`, :func:`.decompose_gates`, :func:`.execute_experiments`, and :func:`.reconstruct_expectation_values` functions.
+    Check out the :ref:`tutorials <circuit cutting tutorials>` for a look at a couple of example circuit cutting workflows.
 
 features:
   - |
@@ -24,8 +24,8 @@ features:
   - |
     Addition of :mod:`~circuit_knitting_toolbox.circuit_cutting.cutting_decomposition`, :mod:`~circuit_knitting_toolbox.circuit_cutting.cutting_execution`,
     and :mod:`~circuit_knitting_toolbox.circuit_cutting.cutting_reconstruction` modules. These modules
-    provide several functions which allow for easy implementation of a gate cutting workflows, namely,
-    the :func:`partition_problem`, :func:`decompose_gates`, :func:`execute_experiments`, and :func:`reconstruct_expectation_value` functions.
+    provide several functions which allow for easy implementation of gate cutting workflows, namely,
+    the :func:`.partition_problem`, :func:`.decompose_gates`, :func:`.execute_experiments`, and :func:`.reconstruct_expectation_values` functions.
 
 issues:
   - |


### PR DESCRIPTION
- use proper sphinx cross references for tutorials & explanation, to prevent bitrot
- fix a few typos
- prefix function xrefs with dots (see also #216)