### PR TITLE
Ensure that each sampler passed to `samplers` is unique

### DIFF
--- a/circuit_knitting_toolbox/circuit_cutting/cutting_evaluation.py
+++ b/circuit_knitting_toolbox/circuit_cutting/cutting_evaluation.py
@@ -94,12 +94,24 @@ def execute_experiments(
     if isinstance(circuits, dict):
         if circuits.keys() != subobservables.keys():
             raise ValueError(
-                "The keys for the circuits and observabes dicts should be equivalent."
+                "The keys for the circuits and observables dicts should be equivalent."
             )
         if isinstance(samplers, dict) and circuits.keys() != samplers.keys():
             raise ValueError(
                 "The keys for the circuits and samplers dicts should be equivalent."
             )
+
+    if isinstance(samplers, dict):
+        # Ensure that each sampler is unique
+        collision_dict: dict[int, str | int] = {}
+        for k, v in samplers.items():
+            if id(v) in collision_dict:
+                raise ValueError(
+                    "Currently, if a samplers dict is passed to execute_experiments(), "
+                    "then each sampler must be unique; however, subsystems "
+                    f"{collision_dict[id(v)]} and {k} were passed the same sampler."
+                )
+            collision_dict[id(v)] = k
 
     # Ensure input Samplers can handle mid-circuit measurements
     _validate_samplers(samplers)

--- a/circuit_knitting_toolbox/circuit_cutting/cutting_evaluation.py
+++ b/circuit_knitting_toolbox/circuit_cutting/cutting_evaluation.py
@@ -74,7 +74,7 @@ def execute_experiments(
         ValueError: ``SingleQubitQPDGate``\ s are not supported in unseparable circuits.
         ValueError: The keys for the input dictionaries are not equivalent.
         ValueError: The input circuits may not contain any classical registers or bits.
-        ValueError: If multiple samplers are passed, each one must currently be unique.
+        ValueError: If multiple samplers are passed, each one must be unique.
     """
     if num_samples <= 0:
         raise ValueError("The number of requested samples must be positive.")

--- a/circuit_knitting_toolbox/circuit_cutting/cutting_evaluation.py
+++ b/circuit_knitting_toolbox/circuit_cutting/cutting_evaluation.py
@@ -74,6 +74,7 @@ def execute_experiments(
         ValueError: ``SingleQubitQPDGate``\ s are not supported in unseparable circuits.
         ValueError: The keys for the input dictionaries are not equivalent.
         ValueError: The input circuits may not contain any classical registers or bits.
+        ValueError: If multiple samplers are passed, each one must currently be unique.
     """
     if num_samples <= 0:
         raise ValueError("The number of requested samples must be positive.")


### PR DESCRIPTION
In the future, we might want the code to behave differently based on whether samplers are identical or merely equivalent.  For instance, perhaps we will want identical samplers to mean that the circuit is evaluated all at once on the hardware, while two equivalent samplers could mean the subcircuits are passed to the backend twice independently (see #220 for details).  For now, since we might want to do this in the future, I believe it makes sense to explicitly disallow it until we figure this out.

I also fixed an unrelated typo in an exception message.