### PR TITLE
Fix the workflow if an empty circuit is provided

### DIFF
--- a/test/circuit_cutting/test_cutting_decomposition.py
+++ b/test/circuit_cutting/test_cutting_decomposition.py
@@ -247,3 +247,12 @@ class TestCuttingDecomposition(unittest.TestCase):
                 e_info.value.args[0]
                 == "Circuits input to execute_experiments should contain no classical registers or bits."
             )
+
+    def test_unused_qubits(self):
+        """Issue #218"""
+        qc = QuantumCircuit(2)
+        subcircuits, _, subobservables = partition_problem(
+            circuit=qc, partition_labels="AB", observables=PauliList(["XX"])
+        )
+        assert subcircuits.keys() == {"A", "B"}
+        assert subobservables.keys() == {"A", "B"}

--- a/test/circuit_cutting/test_cutting_evaluation.py
+++ b/test/circuit_cutting/test_cutting_evaluation.py
@@ -348,14 +348,6 @@ class TestCuttingEvaluation(unittest.TestCase):
 
     def test_workflow_with_unused_qubits(self):
         """Issue #218"""
-        from qiskit import QuantumCircuit
-        from qiskit.quantum_info import PauliList
-        from qiskit_aer.primitives import Sampler
-        from circuit_knitting_toolbox.circuit_cutting import (
-            partition_problem,
-            execute_experiments,
-        )
-
         qc = QuantumCircuit(2)
         subcircuits, _, subobservables = partition_problem(
             circuit=qc, partition_labels="AB", observables=PauliList(["XX"])
@@ -364,5 +356,5 @@ class TestCuttingEvaluation(unittest.TestCase):
             subcircuits,
             subobservables,
             num_samples=1,
-            samplers=Sampler(),
+            samplers=AerSampler(),
         )

--- a/test/circuit_cutting/test_cutting_evaluation.py
+++ b/test/circuit_cutting/test_cutting_evaluation.py
@@ -345,3 +345,24 @@ class TestCuttingEvaluation(unittest.TestCase):
                 e_info.value.args[0]
                 == "Quantum circuit qubit count (2) does not match qubit count of observable(s) (1).  Try providing `qubit_locations` explicitly."
             )
+
+    def test_workflow_with_unused_qubits(self):
+        """Issue #218"""
+        from qiskit import QuantumCircuit
+        from qiskit.quantum_info import PauliList
+        from qiskit_aer.primitives import Sampler
+        from circuit_knitting_toolbox.circuit_cutting import (
+            partition_problem,
+            execute_experiments,
+        )
+
+        qc = QuantumCircuit(2)
+        subcircuits, _, subobservables = partition_problem(
+            circuit=qc, partition_labels="AB", observables=PauliList(["XX"])
+        )
+        execute_experiments(
+            subcircuits,
+            subobservables,
+            num_samples=1,
+            samplers=Sampler(),
+        )

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -415,6 +415,15 @@ class TestTransforms(unittest.TestCase):
                 (frozenset([2]), 0),
             ]
 
+        with self.subTest("Unused qubit"):
+            circuit = QuantumCircuit(2)
+            circuit.x(0)
+            separated_circuits = separate_circuit(circuit, partition_labels="BA")
+            assert separated_circuits.subcircuits.keys() == {"A", "B"}
+            assert len(separated_circuits.subcircuits["B"].data) == 1
+            assert len(separated_circuits.subcircuits["A"].data) == 0
+            assert separated_circuits.qubit_map == [("B", 0), ("A", 0)]
+
 
 def _create_barrier_subcirc() -> QuantumCircuit:
     qc = QuantumCircuit(1)


### PR DESCRIPTION
Closes #218.  I started by modifying `_separate_instructions_by_partition`, but then I encountered a new error, which led me to modify `_circuit_from_instructions` as well.

The only thing I was a little bit unsure about was whether `qc.qubits[j]` would indeed give me the `j`th qubit, but it seems to work: all tests pass.

As a bonus, each subsystem now has a _single_ quantum register which contains all qubits relevant to it.