### PR TITLE
Switch from flit to hatchling build system

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref_name }}
-      - name: Install flit
+      - name: Install hatch
         run: |
           python -m pip install --upgrade pip
-          pip install flit
+          pip install hatch
+      - name: Build using hatch
+        run: |
+          hatch build
       - name: Publish release
         env:
-          FLIT_INDEX_URL: https://upload.pypi.org/legacy/
-          FLIT_USERNAME: __token__
-          FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: flit publish
+          HATCH_INDEX_REPO: https://upload.pypi.org/legacy/
+          HATCH_INDEX_USER: __token__
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          hatch publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "circuit-knitting-toolbox"
@@ -100,6 +100,3 @@ omit = [
     # deprecated import location(s)
     "circuit_knitting_toolbox/circuit_cutting/wire_cutting.py",
 ]
-
-[tool.flit.module]
-name = "circuit_knitting_toolbox"

--- a/tools/extremal_dependency_versions.py
+++ b/tools/extremal_dependency_versions.py
@@ -90,6 +90,12 @@ class CLI:
             d = toml.load(f)
         process_dependencies_in_place(d, mapfunc)
 
+        # Modify pyproject.toml so hatchling will allow direct references
+        # as dependencies.
+        d.setdefault("tool", {}).setdefault("hatch", {}).setdefault("metadata", {})[
+            "allow-direct-references"
+        ] = True
+
         if inplace:
             with open("pyproject.toml", "w") as f:
                 toml.dump(d, f)


### PR DESCRIPTION
This switches from flit_core to [hatchling](https://pypi.org/project/hatchling/) for the build system.  Likewise, it uses [hatch](https://github.com/pypa/hatch) rather than flit in the `release.yml` workflow.

The primary goal here is to enable progress on
- #221

I have not tested the release workflow against the test pypi instance, but everything _looks_ right to me.  If it fails when we do the 0.3.0 release, I am happy to debug.