### PR TITLE
Fix mypy under rustworkx 0.13.0

### DIFF
--- a/circuit_knitting/utils/transforms.py
+++ b/circuit_knitting/utils/transforms.py
@@ -27,7 +27,7 @@ from collections import defaultdict
 from collections.abc import Sequence, Iterable, Hashable, MutableMapping
 from typing import NamedTuple
 
-from rustworkx import PyGraph, connected_components
+from rustworkx import PyGraph, connected_components  # type: ignore[attr-defined]
 from qiskit.circuit import (
     QuantumCircuit,
     CircuitInstruction,
@@ -99,7 +99,7 @@ def separate_circuit(
 def _partition_labels_from_circuit(circuit: QuantumCircuit) -> list[int]:
     """Generate partition labels from the connectivity of a quantum circuit."""
     # Determine connectivity structure of the circuit
-    graph = PyGraph()
+    graph: PyGraph = PyGraph()
     graph.add_nodes_from(range(circuit.num_qubits))
     for instruction in circuit.data:
         qubits = instruction.qubits


### PR DESCRIPTION
This fixes mypy when run with the most recent rustworkx release, 0.13.0.  Without this, mypy errors with

```
circuit_knitting/utils/transforms.py:30: error: Module "rustworkx" has no attribute "connected_components"; maybe "BiconnectedComponents"?  [attr-defined]
circuit_knitting/utils/transforms.py:102: error: Need type annotation for "graph"  [var-annotated]
Found 2 errors in 1 file (checked 36 source files)
```

It's not clear to me, though, why these annotations are necessary.  I expect there is a better solution.