### PR TITLE
Enable tests on Windows

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -24,6 +24,8 @@ jobs:
         include:
           - os: macos-latest
             python-version: "3.8"
+          - os: windows-latest
+            python-version: "3.10"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -44,9 +46,13 @@ jobs:
         run: |
           pver=${{ matrix.python-version }}
           tox -epy${pver/./} -- --run-slow
+          notebook_flags=""
           if [ "$pver" = "3.11" ]; then
             echo Skipping tutorials that require cplex
-            tox -epy${pver/./}-notebook  -- --ignore=docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb --ignore=docs/circuit_cutting/cutqc/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb
-          else
-            tox -epy${pver/./}-notebook
+            notebook_flags="${notebook_flags} --ignore=docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb --ignore=docs/circuit_cutting/cutqc/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb"
           fi
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            echo Skipping tutorials \& how-tos that require pyscf
+            notebook_flags="${notebook_flags} --ignore=docs/entanglement_forging --ignore=docs/_build/jupyter_execute/entanglement_forging/how-tos"
+          fi
+          tox -epy${pver/./}-notebook -- ${notebook_flags}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <div align="left">
 
   [![Stability](https://img.shields.io/badge/Stability-alpha-f4d03f.svg)](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/releases)
-  ![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20macOS-informational)
+  ![Platform](https://img.shields.io/badge/Platform-Linux%20%7C%20macOS%20%7C%20Windows-informational)
   [![Python](https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-informational)](https://www.python.org/)
   [![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%200.43.0-6133BD)](https://github.com/Qiskit/qiskit)
   [![Qiskit Nature](https://img.shields.io/badge/Qiskit%20Nature-%E2%89%A5%200.5.2-6133BD)](https://github.com/Qiskit/qiskit-nature)

--- a/test/forging/test_entanglement_forging_ground_state_solver.py
+++ b/test/forging/test_entanglement_forging_ground_state_solver.py
@@ -12,6 +12,7 @@
 """Tests for EntanglementForgingVQE module."""
 
 import unittest
+import importlib.util
 import numpy as np
 
 from qiskit.algorithms.optimizers import SPSA
@@ -28,12 +29,15 @@ from circuit_knitting.forging import (
     EntanglementForgingGroundStateSolver,
 )
 
+pyscf_available = importlib.util.find_spec("pyscf") is not None
+
 
 class TestEntanglementForgingGroundStateSolver(unittest.TestCase):
     def setUp(self):
         # Hard-code some ansatz params/lambdas
         self.optimizer = SPSA(maxiter=0)
 
+    @unittest.skipIf(not pyscf_available, "pyscf is not installed")
     def test_entanglement_forging_vqe_hydrogen(self):
         """Test of applying Entanglement Forged Solver to to compute the energy of a H2 molecule."""
         # Set up the ElectronicStructureProblem

--- a/test/forging/test_entanglement_forging_knitter.py
+++ b/test/forging/test_entanglement_forging_knitter.py
@@ -12,6 +12,7 @@
 """Tests for EntanglementForgingKnitter module."""
 
 import os
+import importlib.util
 import unittest
 import pytest
 
@@ -29,6 +30,8 @@ from circuit_knitting.forging import (
     cholesky_decomposition,
     convert_cholesky_operator,
 )
+
+pyscf_available = importlib.util.find_spec("pyscf") is not None
 
 
 class TestEntanglementForgingKnitter(unittest.TestCase):
@@ -72,6 +75,7 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
 
         return ansatz
 
+    @unittest.skipIf(not pyscf_available, "pyscf is not installed")
     def test_entanglement_forging_H2(self):
         """
         Test to apply Entanglement Forging to compute the energy of a H2 molecule,
@@ -108,6 +112,7 @@ class TestEntanglementForgingKnitter(unittest.TestCase):
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(energy + energy_shift, -1.121936544469326)
 
+    @unittest.skipIf(not pyscf_available, "pyscf is not installed")
     def test_entanglement_forging_H2O(self):  # pylint: disable=too-many-locals
         """
         Test to apply Entanglement Forging to compute the energy of a H2O molecule,


### PR DESCRIPTION
I realized that the entirety of circuit cutting works on Windows, so we might as well advertise native Windows support and test on it too.

Specific changes in this PR:
- skip tests that require pyscf if it is not available
- add Windows workflow to Actions matrix
- add Windows to README platform badge