### PR TITLE
Set `earliest_version` explicitly in reno config

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -2,3 +2,4 @@
 encoding: utf8
 default_branch: main
 unreleased_version_title: "Upcoming release (``main`` branch)"
+earliest_version: 0.1.0


### PR DESCRIPTION
This is a cherry-pick of 77c6a2f028dc4e797b9e6e8de908fadeb428e603 to `main`.

The original commit, to `stable/0.2`, fixed #248, as that is the branch we currently deploy docs from.  However, we need to fix this on `main` too, so that future release branches have their release notes render correctly.

As before, I'm not sure why this change is necessary, since [the reno documentation](https://docs.openstack.org/reno/latest/user/usage.html#configuring-reno) states "If unset, all versions will be scanned."