### PR TITLE
Add threading and never use duplicate Samplers

### DIFF
--- a/circuit_knitting/cutting/cutting_evaluation.py
+++ b/circuit_knitting/cutting/cutting_evaluation.py
@@ -17,7 +17,7 @@ import copy
 from typing import Any, NamedTuple
 from collections.abc import Sequence
 from itertools import chain
-from multiprocessing import ThreadPool
+from multiprocessing.pool import ThreadPool
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit, ClassicalRegister


### PR DESCRIPTION
We believe the hung jobs are resulting from using the same `Sampler` instance in multiple threads.

I have attempted to fix this by deep copying each `Sampler` in the case where only one `Sampler` is specified but there are multiple partitions. The backend will handle queueing those jobs.

We can continue thinking about this interface, but I'd like to get the ability to parallelize back in if it will behave consistently.

**On Hold** until we coordinate with Runtime team on primitive parallelization.