### PR TITLE
Export `qpdbasis_from_gate` from `qpd` module

### DIFF
--- a/circuit_knitting/cutting/qpd/__init__.py
+++ b/circuit_knitting/cutting/qpd/__init__.py
@@ -12,7 +12,12 @@
 """Main quasiprobability decomposition functionality."""
 
 from .qpd_basis import QPDBasis
-from .qpd import generate_qpd_samples, decompose_qpd_instructions, WeightType
+from .qpd import (
+    generate_qpd_samples,
+    decompose_qpd_instructions,
+    WeightType,
+    qpdbasis_from_gate,
+)
 from .instructions import (
     BaseQPDGate,
     SingleQubitQPDGate,


### PR DESCRIPTION
`qpdbasis_from_gate` is listed in `__all__`, but it currently doesn't get exported because it hasn't been imported.  Actually, this manifests in the following error:

```
>>> from circuit_knitting.cutting.qpd import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'circuit_knitting.cutting.qpd' has no attribute 'qpdbasis_from_gate'
```

(I'm kind of disappointed that ruff doesn't pick this up for us.)