### PR TITLE
Fix bug in result creation and add instantiation of EFGSS to how-to

### DIFF
--- a/circuit_knitting/forging/__init__.py
+++ b/circuit_knitting/forging/__init__.py
@@ -25,6 +25,7 @@ Classes
    EntanglementForgingOperator
    EntanglementForgingAnsatz
    EntanglementForgingGroundStateSolver
+   EntanglementForgingResult
 
 Decomposition Functions
 =======================
@@ -43,6 +44,7 @@ from .entanglement_forging_knitter import EntanglementForgingKnitter
 from .entanglement_forging_operator import EntanglementForgingOperator
 from .entanglement_forging_ground_state_solver import (
     EntanglementForgingGroundStateSolver,
+    EntanglementForgingResult,
 )
 from .cholesky_decomposition import cholesky_decomposition, convert_cholesky_operator
 
@@ -51,6 +53,7 @@ __all__ = [
     "EntanglementForgingKnitter",
     "EntanglementForgingOperator",
     "EntanglementForgingGroundStateSolver",
+    "EntanglementForgingResult",
     "cholesky_decomposition",
     "convert_cholesky_operator",
 ]

--- a/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
+++ b/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
@@ -318,7 +318,7 @@ class EntanglementForgingGroundStateSolver:
         # results of eigenvalue minimization and other meta information
         result = EntanglementForgingResult()
         result.eigenvalues = np.asarray([optimal_evaluation.eigenvalue])
-        result.eigenstates = [optimal_evaluation.eigenstate]
+        result.eigenstates = [(optimal_evaluation.eigenstate, None)]
         result.history = self._history.evaluations
         result.energy_shift = self._energy_shift
         result.elapsed_time = elapsed_time

--- a/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
+++ b/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
@@ -25,7 +25,6 @@ from typing import (
 import scipy
 import numpy as np
 
-from qiskit.algorithms.minimum_eigensolvers import MinimumEigensolverResult
 from qiskit.algorithms.optimizers import SPSA, Optimizer, OptimizerResult
 from qiskit_nature.second_q.problems import (
     ElectronicStructureProblem,
@@ -317,13 +316,9 @@ class EntanglementForgingGroundStateSolver:
 
         # Create the EntanglementForgingResult from the results from the
         # results of eigenvalue minimization and other meta information
-        min_eigsolver_result = MinimumEigensolverResult()
-        min_eigsolver_result.eigenvalue = optimal_evaluation.eigenvalue
-        min_eigsolver_result.eigenstate = optimal_evaluation.eigenstate
-        result = EntanglementForgingResult.from_minimum_eigensolver_result(
-            min_eigsolver_result
-        )
-        result.energy_shift = self._energy_shift
+        result = EntanglementForgingResult()
+        result.eigenvalues = np.asarray([optimal_evaluation.eigenvalue])
+        result.eigenstates = [optimal_evaluation.eigenstate]
         result.history = self._history.evaluations
         result.elapsed_time = elapsed_time
 

--- a/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
+++ b/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
@@ -320,6 +320,7 @@ class EntanglementForgingGroundStateSolver:
         result.eigenvalues = np.asarray([optimal_evaluation.eigenvalue])
         result.eigenstates = [optimal_evaluation.eigenstate]
         result.history = self._history.evaluations
+        result.energy_shift = self._energy_shift
         result.elapsed_time = elapsed_time
 
         # Close any runtime sessions

--- a/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
+++ b/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
@@ -80,13 +80,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The ansatz for Entanglement Forging consists of a set of input bitstrings and a parameterized circuit. (See the [explanatory material](../explanation/index.rst) section of the documentation for additional background on the method.) For this demo, we will use the same bitstrings and ansatz for both the U and V subsystems. "
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
@@ -126,6 +119,13 @@
     "hop_gate.h(0)\n",
     "\n",
     "hop_gate.draw()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create the ansatz with a reduced set of bitstrings."
    ]
   },
   {
@@ -190,6 +190,13 @@
     "ansatz = EntanglementForgingAnsatz(circuit_u=circuit_u, bitstrings_u=reduced_bitstrings)\n",
     "\n",
     "ansatz.circuit_u.draw()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create the ``EntanglementForgingGroundStateSolver``, and specify which orbitals to reduce in the observable."
    ]
   },
   {

--- a/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
+++ b/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-27T13:41:07.878080Z",
@@ -26,8 +26,6 @@
     "from qiskit.circuit import QuantumCircuit, Parameter\n",
     "from qiskit.algorithms.optimizers import COBYLA\n",
     "from qiskit_nature.second_q.drivers import PySCFDriver\n",
-    "from qiskit_nature.second_q.problems import ElectronicBasis\n",
-    "from qiskit_nature.second_q.formats import get_ao_to_mo_from_qcschema\n",
     "\n",
     "from circuit_knitting.forging import (\n",
     "    EntanglementForgingAnsatz,\n",

--- a/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
+++ b/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
@@ -24,7 +24,6 @@
     "import numpy as np\n",
     "\n",
     "from qiskit.circuit import QuantumCircuit, Parameter\n",
-    "from qiskit.algorithms.optimizers import COBYLA\n",
     "from qiskit_nature.second_q.drivers import PySCFDriver\n",
     "\n",
     "from circuit_knitting.forging import (\n",
@@ -203,11 +202,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "optimizer = COBYLA(maxiter=100)\n",
-    "\n",
     "solver = EntanglementForgingGroundStateSolver(\n",
     "    ansatz=ansatz,\n",
-    "    optimizer=optimizer,\n",
     "    orbitals_to_reduce=orbitals_to_reduce,\n",
     ")"
    ]

--- a/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
+++ b/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
@@ -10,15 +10,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Import the relevant modules\n",
-    "\n",
-    "First, we import the relevant modules.  The imports are similar to the introductory tutorial, but this time, we also import the `reduce_bitstrings` function from `circuit_knitting.utils`."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -33,11 +24,14 @@
     "import numpy as np\n",
     "\n",
     "from qiskit.circuit import QuantumCircuit, Parameter\n",
+    "from qiskit.algorithms.optimizers import COBYLA\n",
     "from qiskit_nature.second_q.drivers import PySCFDriver\n",
     "from qiskit_nature.second_q.problems import ElectronicBasis\n",
+    "from qiskit_nature.second_q.formats import get_ao_to_mo_from_qcschema\n",
     "\n",
     "from circuit_knitting.forging import (\n",
     "    EntanglementForgingAnsatz,\n",
+    "    EntanglementForgingGroundStateSolver,\n",
     ")\n",
     "from circuit_knitting.utils import reduce_bitstrings"
    ]
@@ -70,11 +64,12 @@
     "H2_x = radius_2 * np.cos(np.pi / 180 * thetas_in_deg)\n",
     "H2_y = radius_2 * np.sin(np.pi / 180 * thetas_in_deg)\n",
     "\n",
+    "# Create an ElectronicStructureProblem from the molecule using PySCFDriver\n",
     "driver = PySCFDriver(\n",
     "    f\"O 0.0 0.0 0.0; H {H1_x} 0.0 0.0; H {H2_x} {H2_y} 0.0\", basis=\"sto6g\"\n",
     ")\n",
     "driver.run()\n",
-    "problem = driver.to_problem(basis=ElectronicBasis.AO)"
+    "problem = driver.to_problem()"
    ]
   },
   {
@@ -198,6 +193,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = COBYLA(maxiter=100)\n",
+    "\n",
+    "solver = EntanglementForgingGroundStateSolver(\n",
+    "    ansatz=ansatz,\n",
+    "    optimizer=optimizer,\n",
+    "    orbitals_to_reduce=orbitals_to_reduce,\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -206,13 +216,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.23.3</td></tr><tr><td><code>qiskit-aer</code></td><td>0.12.0</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.20.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.5.2</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.8.16</td></tr><tr><td>Python compiler</td><td>Clang 14.0.6 </td></tr><tr><td>Python build</td><td>default, Mar  1 2023 21:19:10</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>32.0</td></tr><tr><td colspan='2'>Tue Apr 11 19:14:09 2023 CDT</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.24.0</td></tr><tr><td><code>qiskit-aer</code></td><td>0.12.0</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.20.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.6.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.8.16</td></tr><tr><td>Python compiler</td><td>Clang 14.0.6 </td></tr><tr><td>Python build</td><td>default, Mar  1 2023 21:19:10</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>32.0</td></tr><tr><td colspan='2'>Sat Jun 17 11:51:45 2023 CDT</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"

--- a/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
+++ b/docs/entanglement_forging/how-tos/freeze-orbitals.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-04-27T13:41:07.878080Z",
@@ -37,9 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Instantiate the `ElectronicStructureProblem`\n",
-    "\n",
-    "Next, we set up the $\\mathrm{H}_2\\mathrm{O}$ molecule, specify the driver and converter, and instantiate an `ElectronicStructureProblem`."
+    "First, we set up the $\\mathrm{H}_2\\mathrm{O}$ molecule, specify the driver and converter, and instantiate an `ElectronicStructureProblem`."
    ]
   },
   {
@@ -73,61 +71,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Prepare the bitstrings and the ansatz"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">     ┌───┐┌───┐     ┌────────────┐     ┌───┐\n",
-       "q_0: ┤ H ├┤ X ├──■──┤ Ry(-1.0*θ) ├──■──┤ H ├\n",
-       "     └───┘└─┬─┘┌─┴─┐├────────────┤┌─┴─┐└───┘\n",
-       "q_1: ───────■──┤ X ├┤ Ry(-1.0*θ) ├┤ X ├─────\n",
-       "               └───┘└────────────┘└───┘     </pre>"
-      ],
-      "text/plain": [
-       "     ┌───┐┌───┐     ┌────────────┐     ┌───┐\n",
-       "q_0: ┤ H ├┤ X ├──■──┤ Ry(-1.0*θ) ├──■──┤ H ├\n",
-       "     └───┘└─┬─┘┌─┴─┐├────────────┤┌─┴─┐└───┘\n",
-       "q_1: ───────■──┤ X ├┤ Ry(-1.0*θ) ├┤ X ├─────\n",
-       "               └───┘└────────────┘└───┘     "
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "theta = Parameter(\"θ\")\n",
-    "\n",
-    "hop_gate = QuantumCircuit(2, name=\"Hop gate\")\n",
-    "hop_gate.h(0)\n",
-    "hop_gate.cx(1, 0)\n",
-    "hop_gate.cx(0, 1)\n",
-    "hop_gate.ry(-theta, 0)\n",
-    "hop_gate.ry(-theta, 1)\n",
-    "hop_gate.cx(0, 1)\n",
-    "hop_gate.h(0)\n",
-    "\n",
-    "hop_gate.draw()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Create the ansatz with a reduced set of bitstrings."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -159,12 +108,23 @@
        "     └───────────────┘└──────────────┘└───────────────┘"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "theta = Parameter(\"θ\")\n",
+    "\n",
+    "hop_gate = QuantumCircuit(2, name=\"Hop gate\")\n",
+    "hop_gate.h(0)\n",
+    "hop_gate.cx(1, 0)\n",
+    "hop_gate.cx(0, 1)\n",
+    "hop_gate.ry(-theta, 0)\n",
+    "hop_gate.ry(-theta, 1)\n",
+    "hop_gate.cx(0, 1)\n",
+    "hop_gate.h(0)\n",
+    "\n",
     "theta_1, theta_2, theta_3, theta_4 = (\n",
     "    Parameter(\"θ1\"),\n",
     "    Parameter(\"θ2\"),\n",
@@ -193,12 +153,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create the ``EntanglementForgingGroundStateSolver``, and specify which orbitals to reduce in the observable."
+    "Create the ``EntanglementForgingGroundStateSolver``, and specify which orbitals to reduce in the problem."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,13 +177,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.24.0</td></tr><tr><td><code>qiskit-aer</code></td><td>0.12.0</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.20.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.6.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.8.16</td></tr><tr><td>Python compiler</td><td>Clang 14.0.6 </td></tr><tr><td>Python build</td><td>default, Mar  1 2023 21:19:10</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>32.0</td></tr><tr><td colspan='2'>Sat Jun 17 11:51:45 2023 CDT</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.24.0</td></tr><tr><td><code>qiskit-aer</code></td><td>0.12.0</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.20.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.6.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.8.16</td></tr><tr><td>Python compiler</td><td>Clang 14.0.6 </td></tr><tr><td>Python build</td><td>default, Mar  1 2023 21:19:10</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>32.0</td></tr><tr><td colspan='2'>Sun Jun 18 20:55:50 2023 CDT</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"

--- a/releasenotes/notes/ef-results-bug-5aa84ca5611dd827.yaml
+++ b/releasenotes/notes/ef-results-bug-5aa84ca5611dd827.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed a bug in :class:`~circuit_knitting.forging.EntanglementForgingGroundStateSolver` which was causing
-    AttributeErrors when instantiating the `~circuit_knitting.forging.EntanglementForgingResult` in certain
+    ``AttributeError``\ s when instantiating the `~circuit_knitting.forging.EntanglementForgingResult` in certain
     conditions, such as when reducing the orbitals over which to solve.

--- a/releasenotes/notes/ef-results-bug-5aa84ca5611dd827.yaml
+++ b/releasenotes/notes/ef-results-bug-5aa84ca5611dd827.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`~circuit_knitting.forging.EntanglementForgingGroundStateSolver` which was causing
+    AttributeErrors when instantiating the `~circuit_knitting.forging.EntanglementForgingResult` in certain
+    conditions, such as when reducing the orbitals over which to solve.

--- a/test/forging/test_entanglement_forging_ground_state_solver.py
+++ b/test/forging/test_entanglement_forging_ground_state_solver.py
@@ -70,6 +70,7 @@ class TestEntanglementForgingGroundStateSolver(unittest.TestCase):
         # Solve for the ground state energy
         results = solver.solve(problem)
         ground_state_energy = results.groundenergy + results.energy_shift
-
+        print(results.groundenergy)
+        print(results.energy_shift)
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(ground_state_energy, -1.121936544469326)

--- a/test/forging/test_entanglement_forging_ground_state_solver.py
+++ b/test/forging/test_entanglement_forging_ground_state_solver.py
@@ -70,7 +70,5 @@ class TestEntanglementForgingGroundStateSolver(unittest.TestCase):
         # Solve for the ground state energy
         results = solver.solve(problem)
         ground_state_energy = results.groundenergy + results.energy_shift
-        print(results.groundenergy)
-        print(results.energy_shift)
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(ground_state_energy, -1.121936544469326)

--- a/test/forging/test_entanglement_forging_ground_state_solver.py
+++ b/test/forging/test_entanglement_forging_ground_state_solver.py
@@ -70,5 +70,6 @@ class TestEntanglementForgingGroundStateSolver(unittest.TestCase):
         # Solve for the ground state energy
         results = solver.solve(problem)
         ground_state_energy = results.groundenergy + results.energy_shift
+
         # Ensure ground state energy output is within tolerance
         self.assertAlmostEqual(ground_state_energy, -1.121936544469326)


### PR DESCRIPTION
Resolves #132 
Resolves #247 

This PR fixes a bug which was preventing the EFResults from being properly populated in certain cases, such as when we include `orbitals_to_reduce` argument to `EFGSSolver`

It also introduces an instantiation of the `EFGroundStateSolver` in the bitstring reduction how-to. Users need to pass in the orbitals to reduce here, as well as the ansatz, so that the observable can be properly reduced as well. This has been a point of confusion, so adding this step should clear this confusion up.