### PR TITLE
Move configuration out of `extremal-python-dependencies`

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -31,7 +31,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip tox
           python -m pip install toml typer
-          python tools/extremal-python-dependencies.py pin-dependencies dev --inplace
+          python tools/extremal-python-dependencies.py pin-dependencies \
+              "qiskit-terra @ git+https://github.com/Qiskit/qiskit-terra.git" \
+              "qiskit-nature @ git+https://github.com/qiskit-community/qiskit-nature.git" \
+              "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \
+              --inplace
       - name: Modify tox.ini for more thorough check
         shell: bash
         run: |

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -30,7 +30,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install toml typer
           pip install "tox==$(python tools/extremal-python-dependencies.py get-tox-minversion)"
-          python tools/extremal-python-dependencies.py pin-dependencies min --inplace
+          python tools/extremal-python-dependencies.py pin-dependencies-to-minimum --inplace
       - name: Modify tox.ini for more thorough check
         shell: bash
         run: |

--- a/tools/extremal-python-dependencies.py
+++ b/tools/extremal-python-dependencies.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+from __future__ import annotations
+
 import re
 import configparser
 

--- a/tools/extremal-python-dependencies.py
+++ b/tools/extremal-python-dependencies.py
@@ -10,10 +10,9 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from __future__ import annotations
-
 import re
 import configparser
+from typing import List
 
 import toml
 import typer
@@ -23,7 +22,7 @@ import typer
 _name_re = re.compile(r"^([A-Z0-9][A-Z0-9._-]*[A-Z0-9])", re.IGNORECASE)
 
 
-def mapfunc_replace(replacements: list[str]):
+def mapfunc_replace(replacements: List[str]):
     """Use the provided version(s) of certain packages"""
     d: dict[str, str] = {}
     for r in replacements:
@@ -126,7 +125,7 @@ def pin_dependencies_to_minimum(inplace: bool = False):
 
 
 @app.command()
-def pin_dependencies(replacements: list[str], inplace: bool = False):
+def pin_dependencies(replacements: List[str], inplace: bool = False):
     """Pin dependencies in `pyproject.toml` to the provided versions."""
     _pin_dependencies(mapfunc_replace(replacements), inplace)
 

--- a/tools/extremal-python-dependencies.py
+++ b/tools/extremal-python-dependencies.py
@@ -17,17 +17,35 @@ import toml
 import typer
 
 
-def mapfunc_dev(dep):
-    """Load the development version(s) of certain Qiskit-related packages"""
-    # https://peps.python.org/pep-0440/#direct-references
-    return re.sub(
-        r"^(qiskit-(?:terra|ibm-runtime)).*$",
-        r"\1 @ git+https://github.com/Qiskit/\1.git",
-        dep,
-    )
+# https://peps.python.org/pep-0508/#names
+_name_re = re.compile(r"^([A-Z0-9][A-Z0-9._-]*[A-Z0-9])", re.IGNORECASE)
 
 
-def mapfunc_min(dep):
+def mapfunc_replace(replacements: list[str]):
+    """Use the provided version(s) of certain packages"""
+    d: dict[str, str] = {}
+    for r in replacements:
+        match = _name_re.match(r)
+        if match is None:
+            raise RuntimeError(f"Replacement dependency does not match PEP 508: {r}")
+        name = match.group()
+        if name in d:
+            raise RuntimeError("Duplicate name")
+        d[name] = r
+
+    def _mapfunc_replace(dep):
+        # Replace https://peps.python.org/pep-0508/#names with provided
+        # version, often a https://peps.python.org/pep-0440/#direct-references
+        match = _name_re.match(dep)
+        if match is None:
+            raise RuntimeError(f"Dependency does not match PEP 508: `{dep}`")
+        dep_name = match.group()
+        return d.get(dep_name, dep)
+
+    return _mapfunc_replace
+
+
+def mapfunc_minimum(dep):
     """Set each dependency to its minimum version"""
     return re.sub(r"[>~]=", r"==", dep)
 
@@ -81,14 +99,7 @@ def get_tox_minversion():
     print(config["tox"]["minversion"])
 
 
-@app.command()
-def pin_dependencies(strategy, inplace: bool = False):
-    """Pin the dependencies in `pyproject.toml` according to `strategy`"""
-    mapfunc = {
-        "dev": mapfunc_dev,
-        "min": mapfunc_min,
-    }[strategy]
-
+def _pin_dependencies(mapfunc, inplace: bool):
     with open("pyproject.toml") as f:
         d = toml.load(f)
     process_dependencies_in_place(d, mapfunc)
@@ -104,6 +115,18 @@ def pin_dependencies(strategy, inplace: bool = False):
             toml.dump(d, f)
     else:
         print(toml.dumps(d))
+
+
+@app.command()
+def pin_dependencies_to_minimum(inplace: bool = False):
+    """Pin all dependencies in `pyproject.toml` to their minimum versions."""
+    _pin_dependencies(mapfunc_minimum, inplace)
+
+
+@app.command()
+def pin_dependencies(replacements: list[str], inplace: bool = False):
+    """Pin dependencies in `pyproject.toml` to the provided versions."""
+    _pin_dependencies(mapfunc_replace(replacements), inplace)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This modifies the `extremal-python-dependencies` script so that it is configured on the command line.  This is one step toward making it a standard script.  Configuration is now provided by command line flags in the CI workflows.