### PR TITLE
Update EF how-to index

### DIFF
--- a/docs/entanglement_forging/how-tos/index.rst
+++ b/docs/entanglement_forging/how-tos/index.rst
@@ -4,9 +4,7 @@
 Entanglement Forging How-To Guides
 ##################################
 
-.. toctree::
-  :maxdepth: 3
+.. nbgallery::
+    :glob:
 
-  How to specify the problem <specify-problem>
-  How to use asymmetric bitstrings <use-asymmetric-bitstrings>
-  How to freeze orbitals <freeze-orbitals>
+    *


### PR DESCRIPTION
This PR prevents the how-to index in EF from rendering weirdly in the docs. It also brings it more in line with how the other tools' how-to's are indexed