### PR TITLE
Ignore opflow warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,4 @@ omit = [
 [tool.pytest.ini_options]
 testpaths = ["./test/"]
 filterwarnings = ["ignore:::.*opflow*"]
+addopts = "--doctest-modules -rs --durations=10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,7 @@ omit = [
     # deprecated import location(s)
     "circuit_knitting/cutting/wire_cutting.py",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["./test/"]
+filterwarnings = ["ignore:::.*opflow*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,5 +110,5 @@ omit = [
 
 [tool.pytest.ini_options]
 testpaths = ["./test/"]
-filterwarnings = ["ignore:::.*opflow*"]
+filterwarnings = ["ignore:::.*qiskit.opflow*"]
 addopts = "--doctest-modules -rs --durations=10"

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,3 @@ commands =
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "stubs", ignore_errors=True)'
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "_build" / "html" / ".doctrees", ignore_errors=True)'
   sphinx-build -j auto -b html -W -T --keep-going {posargs} docs/ docs/_build/html
-
-[pytest]
-addopts = --doctest-modules -rs --durations=10

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ extras =
   test
   cplex
 commands =
-  pytest test/ {posargs}
+  pytest {posargs}
 
 [testenv:style]
 extras =


### PR DESCRIPTION
This PR ignores *all warnings* from opflow, which is being prohibitively noisy in our unit tests. It brings our total warnings down from 104 to 14. This would ignore non-deprecation-warnings as well, but since opflow is deprecated and we do not use it directly in our source code, this is an acceptable tradeoff.

This PR also specifies the test path in the new pytest config in `pyproject.toml`, so it no longer needs to be specified in `tox.ini`, so we remove it in tox.