### PR TITLE
Fix bug in decompose-qpd-instructions

### DIFF
--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -426,6 +426,8 @@ def _decompose_qpd_instructions(
             continue  # pragma: no cover
         if isinstance(circuit.data[decomp[0]].operation, TwoQubitQPDGate):
             qpdgate_ids_2q.append(decomp[0])
+
+    qpdgate_ids_2q = sorted(qpdgate_ids_2q)
     data_id_offset = 0
     for i in qpdgate_ids_2q:
         inst = circuit.data[i + data_id_offset]

--- a/releasenotes/notes/dx-qpd-inst-bug-fe9c50dad716b848.yaml
+++ b/releasenotes/notes/dx-qpd-inst-bug-fe9c50dad716b848.yaml
@@ -3,4 +3,4 @@ fixes:
   - |
     Fixed a bug in :func:`~circuit_knitting.cutting.qpd.decompose_qpd_instructions` which would
     cause index errors if :class:`~circuit_knitting.cutting.qpd.TwoQubitQPDGate` indices were
-    specified out of order.
+    not specified in ascending order.

--- a/releasenotes/notes/dx-qpd-inst-bug-fe9c50dad716b848.yaml
+++ b/releasenotes/notes/dx-qpd-inst-bug-fe9c50dad716b848.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :func:`~circuit_knitting.cutting.qpd.decompose_qpd_instructions` which would
+    cause index errors if :class:`~circuit_knitting.cutting.qpd.TwoQubitQPDGate` indices were
+    specified out of order.

--- a/test/cutting/qpd/test_qpd.py
+++ b/test/cutting/qpd/test_qpd.py
@@ -148,7 +148,7 @@ class TestQPDFunctions(unittest.TestCase):
                 e_info.value.args[0]
                 == "The number of map IDs (1) must equal the number of decompositions in the circuit (2)."
             )
-        with self.subTest("test_unordered_indices"):
+        with self.subTest("Test unordered indices"):
             decomp = QPDBasis.from_gate(RXXGate(np.pi / 3))
             qpd_gate1 = TwoQubitQPDGate(basis=decomp)
             qpd_gate2 = TwoQubitQPDGate(basis=decomp)

--- a/test/cutting/qpd/test_qpd.py
+++ b/test/cutting/qpd/test_qpd.py
@@ -148,6 +148,17 @@ class TestQPDFunctions(unittest.TestCase):
                 e_info.value.args[0]
                 == "The number of map IDs (1) must equal the number of decompositions in the circuit (2)."
             )
+        with self.subTest("test_unordered_indices"):
+            decomp = QPDBasis.from_gate(RXXGate(np.pi / 3))
+            qpd_gate1 = TwoQubitQPDGate(basis=decomp)
+            qpd_gate2 = TwoQubitQPDGate(basis=decomp)
+
+            qc = QuantumCircuit(2)
+            qc.append(CircuitInstruction(qpd_gate1, qubits=[0, 1]))
+            qc.x([0, 1])
+            qc.y([0, 1])
+            qc.append(CircuitInstruction(qpd_gate2, qubits=[0, 1]))
+            decompose_qpd_instructions(qc, [[5], [0]], map_ids=[0, 0])
         with self.subTest("Test measurement"):
             qpd_circ = QuantumCircuit(2)
             qpd_inst = CircuitInstruction(self.qpd_gate1, qubits=[0, 1])
@@ -170,7 +181,6 @@ class TestQPDFunctions(unittest.TestCase):
                 e_info.value.args[0]
                 == "Each decomposition must contain either one or two elements. Found a decomposition with (0) elements."
             )
-
         with self.subTest("test_mismatching_qpd_ids"):
             decomp = QPDBasis.from_gate(RXXGate(np.pi / 3))
             qpd_gate = TwoQubitQPDGate(basis=decomp)


### PR DESCRIPTION
If `TwoQubitQPDGate` indices are specified out of order in the arguments to `decompose_qpd_instructions`, the  [data_id_offset](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/665196fc9b14f31d620e489e18fb339b33deb895/circuit_knitting/cutting/qpd/qpd.py#L429) variable specified in the function will not work as intended when decomposing those gates, and gates which are not `BaseQPDGate` instances will be treated as QPD gates, causing mysterious index errors.

This PR fixes that bug and implements a unit test to test against this problem.