### PR TITLE
Add a supported_gates function

### DIFF
--- a/circuit_knitting/cutting/__init__.py
+++ b/circuit_knitting/cutting/__init__.py
@@ -56,6 +56,7 @@ Quasi-Probability Decomposition (QPD)
 
     qpd.generate_qpd_samples
     qpd.decompose_qpd_instructions
+    qpd.supported_gates
 
 CutQC
 =====

--- a/circuit_knitting/cutting/qpd/__init__.py
+++ b/circuit_knitting/cutting/qpd/__init__.py
@@ -17,6 +17,7 @@ from .qpd import (
     decompose_qpd_instructions,
     WeightType,
     qpdbasis_from_gate,
+    supported_gates,
 )
 from .instructions import (
     BaseQPDGate,
@@ -29,6 +30,7 @@ __all__ = [
     "qpdbasis_from_gate",
     "generate_qpd_samples",
     "decompose_qpd_instructions",
+    "supported_gates",
     "QPDBasis",
     "BaseQPDGate",
     "TwoQubitQPDGate",

--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -215,14 +215,14 @@ def qpdbasis_from_gate(gate: Gate) -> QPDBasis:
         return f(gate)
 
 
-def supported_gates() -> tuple[str]:
+def supported_gates() -> set[str]:
     """
     Return a list of gate names which are supported for automatic decomposition.
 
     Returns:
         Tuple containing names of gates which are supported for automatic decomposition.
     """
-    return ("rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz")
+    return {"rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz"}
 
 
 @_register_qpdbasis_from_gate("rxx", "ryy", "rzz", "crx", "cry", "crz")

--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -215,6 +215,16 @@ def qpdbasis_from_gate(gate: Gate) -> QPDBasis:
         return f(gate)
 
 
+def supported_gates() -> tuple[str]:
+    """
+    Return a list of gate names which are supported for automatic decomposition.
+
+    Returns:
+        Tuple containing names of gates which are supported for automatic decomposition.
+    """
+    return ("rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz")
+
+
 @_register_qpdbasis_from_gate("rxx", "ryy", "rzz", "crx", "cry", "crz")
 def _(gate: RXXGate | RYYGate | RZZGate | CRXGate | CRYGate | CRZGate):
     # Constructing a virtual two-qubit gate by sampling single-qubit operations - Mitarai et al

--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -222,7 +222,7 @@ def supported_gates() -> set[str]:
     Returns:
         Set of gate names supported for automatic decomposition.
     """
-    return {"rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz"}
+    return set(_qpdbasis_from_gate_funcs)
 
 
 @_register_qpdbasis_from_gate("rxx", "ryy", "rzz", "crx", "cry", "crz")

--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -217,10 +217,10 @@ def qpdbasis_from_gate(gate: Gate) -> QPDBasis:
 
 def supported_gates() -> set[str]:
     """
-    Return a list of gate names which are supported for automatic decomposition.
+    Return a set of gate names supported for automatic decomposition.
 
     Returns:
-        Tuple containing names of gates which are supported for automatic decomposition.
+        Set of gate names supported for automatic decomposition.
     """
     return {"rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz"}
 

--- a/releasenotes/notes/supported-gates-d2156f58bc07fc7a.yaml
+++ b/releasenotes/notes/supported-gates-d2156f58bc07fc7a.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Addition of :func:`~circuit_knitting.cutting.qpd.supported_gates` function, which returns the names of all gates which may be automatically decomposed using :func:`~circuit_knitting.cutting.qpd.qpdbasis_from_gate`.

--- a/test/cutting/qpd/test_qpd.py
+++ b/test/cutting/qpd/test_qpd.py
@@ -273,5 +273,5 @@ class TestQPDFunctions(unittest.TestCase):
     def test_supported_gates(self):
         supported_gates = supported_gates()
         self.assertEqual(
-            ("rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz"), supported_gates
+            {"rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz"}, supported_gates
         )

--- a/test/cutting/qpd/test_qpd.py
+++ b/test/cutting/qpd/test_qpd.py
@@ -271,7 +271,5 @@ class TestQPDFunctions(unittest.TestCase):
         assert len(unique_by_eq(b for (a, b) in relevant_maps)) == q1_num_unique
 
     def test_supported_gates(self):
-        supported_gates = supported_gates()
-        self.assertEqual(
-            {"rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz"}, supported_gates
-        )
+        gates = supported_gates()
+        self.assertEqual({"rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz"}, gates)

--- a/test/cutting/qpd/test_qpd.py
+++ b/test/cutting/qpd/test_qpd.py
@@ -269,3 +269,9 @@ class TestQPDFunctions(unittest.TestCase):
         ]
         assert len(unique_by_eq(a for (a, b) in relevant_maps)) == q0_num_unique
         assert len(unique_by_eq(b for (a, b) in relevant_maps)) == q1_num_unique
+
+    def test_supported_gates(self):
+        supported_gates = supported_gates()
+        self.assertEqual(
+            ("rxx", "ryy", "rzz", "crx", "cry", "crz", "cx", "cz"), supported_gates
+        )


### PR DESCRIPTION
There should be a central place where users can find out whether or not a gate is supported without using a `try` block and querying `qpdbasis_from_gate`. I've addressed this here with a simple function that returns a hard-coded `set`. I had also considered a function which takes a gate as input and returns a `bool`, but I just think this implementation is better for both the dev and user.