### PR TITLE
Add `py-notebook` and `py3-notebook` tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
   mypy circuit_knitting/ circuit_knitting_toolbox/
   reno lint
 
-[testenv:{,py38-,py39-,py310-,py311-}notebook]
+[testenv:{,py-,py3-,py38-,py39-,py310-,py311-}notebook]
 extras =
   nbtest
   notebook-dependencies


### PR DESCRIPTION
Sometimes I type these.  It'd be nice to have them do the right thing, rather than invoke the default environment.