### PR TITLE
Add explicit numpy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 requires-python = ">=3.8"
 
 dependencies = [
+    "numpy>=1.23.0",
     "qiskit-aer>=0.12.0",
     "qiskit-terra>=0.24.0",
     "qiskit-nature>=0.6.0",

--- a/releasenotes/notes/explicit-numpy-dependency-fdd89846b37a8d4c.yaml
+++ b/releasenotes/notes/explicit-numpy-dependency-fdd89846b37a8d4c.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Numpy 1.23.0 or later is now required.  The :func:`~numpy.kron`
+    method in earlier versions `has known performance issues
+    <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/pull/70#issuecomment-1500514513>`__,
+    and this method is used heavily by the CutQC wire cutting module.


### PR DESCRIPTION
We are currently relying on numpy being installed as a transitive dependency (through, at the very least, Qiskit Terra).  Even better would be to specific it explicitly, and to set the minimum version following https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/pull/70#issuecomment-1501957148.

#### TODO
- [x] add a release note