### PR TITLE
Add explicit dependency on rustworkx and scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ requires-python = ">=3.8"
 
 dependencies = [
     "numpy>=1.23.0",
+    "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
     "qiskit-terra>=0.24.0",
     "qiskit-nature>=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "numpy>=1.23.0",
     # scipy is currently bounded from above because scipy 1.11 removed the
     # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
-    "scipy>=1.5,<1.11",
+    "scipy>=1.5.2,<1.11",
     "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
     "qiskit-terra>=0.24.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ requires-python = ">=3.8"
 
 dependencies = [
     "numpy>=1.23.0",
+    # scipy is currently bounded from above because scipy 1.11 removed the
+    # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
+    "scipy>=1.5,<1.11",
     "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
     "qiskit-terra>=0.24.0",


### PR DESCRIPTION
This is similar to #286 in that it adds an explicit dependency on something that we are already importing directly (in this case, rustworkx).  I set the minimum version to 0.12.0 since that is what Qiskit Terra 0.24.0 requires.