### PR TITLE
Upload docs build in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           name: html_docs
           path: ./docs/_build/html
-
       - name: Deploy docs
         if: ${{ github.ref == 'refs/heads/stable/0.2' }}
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,13 @@ jobs:
         shell: bash
         run: |
           tox -edocs
+      - name: Upload docs artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: html_docs
+          path: ./docs/_build/html
+
       - name: Deploy docs
         if: ${{ github.ref == 'refs/heads/stable/0.2' }}
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This is useful to iterate on docs and debug CI issues.

The artifact will be uploaded to GitHub Actions like this:

<img width="949" alt="Screenshot 2023-07-10 at 7 56 47 AM" src="https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/assets/14852634/4fd7e8d3-74ac-4f6c-ae9e-7dbd1d691402">
