### PR TITLE
don't enumerate figures and code snippets

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ extensions = [
     "qiskit_sphinx_theme",
 ]
 templates_path = ["_templates"]
-numfig = True
+numfig = False
 numfig_format = {"table": "Table %s"}
 language = "en"
 pygments_style = "colorful"


### PR DESCRIPTION
We have no reason to keep a running enumeration on our figures and/or code snippets, and when `numfig` is set to `True` in `docs/conf.py`, it causes code snippets and figures with captions to have their caption prepended with `Listing #`. We can turn this back on and reckon with captions later if need be, but let's turn it off for now. It clutters the code snippet captions pretty badly