### PR TITLE
Run slow tests for coverage only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,7 @@ extras =
   test
   cplex
 commands =
-  coverage3 run --source circuit_knitting --parallel-mode -m pytest test/ --coverage {posargs}
-  coverage3 run --source circuit_knitting --parallel-mode -m pytest -m slow test/ --coverage {posargs}
+  coverage3 run --source circuit_knitting --parallel-mode -m pytest --run-slow test/ --coverage {posargs}
   coverage3 combine
   coverage3 html
   coverage3 report --fail-under=100 --show-missing --omit="circuit_knitting/cutting/cutqc/**/*,circuit_knitting/forging/**/*,circuit_knitting/utils/conversion.py,circuit_knitting/utils/metrics.py,circuit_knitting/utils/orbital_reduction.py"

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ extras =
   test
   cplex
 commands =
-  coverage3 run --source circuit_knitting --parallel-mode -m pytest test/ --coverage {posargs}
+  coverage3 run --source circuit_knitting --parallel-mode -m pytest --slow test/ --coverage {posargs}
   coverage3 combine
   coverage3 html
   coverage3 report --fail-under=100 --show-missing --omit="circuit_knitting/cutting/cutqc/**/*,circuit_knitting/forging/**/*,circuit_knitting/utils/conversion.py,circuit_knitting/utils/metrics.py,circuit_knitting/utils/orbital_reduction.py"

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,8 @@ extras =
   test
   cplex
 commands =
-  coverage3 run --source circuit_knitting --parallel-mode -m pytest --slow test/ --coverage {posargs}
+  coverage3 run --source circuit_knitting --parallel-mode -m pytest test/ --coverage {posargs}
+  coverage3 run --source circuit_knitting --parallel-mode -m pytest -m slow test/ --coverage {posargs}
   coverage3 combine
   coverage3 html
   coverage3 report --fail-under=100 --show-missing --omit="circuit_knitting/cutting/cutqc/**/*,circuit_knitting/forging/**/*,circuit_knitting/utils/conversion.py,circuit_knitting/utils/metrics.py,circuit_knitting/utils/orbital_reduction.py"


### PR DESCRIPTION
#307 includes a slow test that also provides important code coverage. I suggest we run slow tests on coverage only. This will allow us to continue to test a higher proportion of our code without bogging down every workflow with slow tests.