### PR TITLE
Add caption headers to site table of contents

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,8 +35,6 @@ Contents
 
   About Circuit Knitting Toolbox <self>
   Installation Instructions <install>
-  API References <apidocs/index>
-  Release Notes <release-notes>
 
 .. toctree::
   :maxdepth: 2
@@ -54,6 +52,13 @@ Contents
   Entanglement Forging Tutorials <entanglement_forging/tutorials/index>
   Entanglement Forging Explanatory Material <entanglement_forging/explanation/index>
   Entanglement Forging How-To Guides <entanglement_forging/how-tos/index>
+
+.. toctree::
+  :maxdepth: 2
+  :caption: References
+
+  API References <apidocs/index>
+  Release Notes <release-notes>
 
 .. Hiding - Indices and tables
    :ref:`genindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,16 +33,27 @@ Contents
 .. toctree::
   :maxdepth: 2
 
+  About Circuit Knitting Toolbox <self>
   Installation Instructions <install>
+  API References <apidocs/index>
+  Release Notes <release-notes>
+
+.. toctree::
+  :maxdepth: 2
+  :caption: Circuit Cutting
+
   Circuit Cutting Tutorials <circuit_cutting/tutorials/index>
   Circuit Cutting Explanatory Material <circuit_cutting/explanation/index>
   Circuit Cutting How-To Guides <circuit_cutting/how-tos/index>
   CutQC (legacy circuit cutting implementation) <circuit_cutting/cutqc/index>
+
+.. toctree::
+  :maxdepth: 2
+  :caption: Entanglement Forging
+
   Entanglement Forging Tutorials <entanglement_forging/tutorials/index>
   Entanglement Forging Explanatory Material <entanglement_forging/explanation/index>
   Entanglement Forging How-To Guides <entanglement_forging/how-tos/index>
-  API References <apidocs/index>
-  Release Notes <release-notes>
 
 .. Hiding - Indices and tables
    :ref:`genindex`


### PR DESCRIPTION
This keeps the same order of docs, but adds section headers so it's more obvious what is what.

It also adds a page to `<self>` so that you can go back to the home page.

Before:

![Screenshot 2023-07-12 at 10 24 47 AM](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/assets/14852634/5d6d0a13-0fc3-4a46-8762-af361e3561db)

After:

<img width="290" alt="Screenshot 2023-07-14 at 9 54 02 AM" src="https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/assets/14852634/c94976a6-08d5-432f-84d0-9c8269bf8e0a">
