### PR TITLE
Use getters/setters internally in forging

### DIFF
--- a/circuit_knitting/forging/entanglement_forging_ansatz.py
+++ b/circuit_knitting/forging/entanglement_forging_ansatz.py
@@ -79,9 +79,9 @@ class EntanglementForgingAnsatz:
                     "There must be the same number of V bitstrings as U bitstrings."
                 )
 
-        self._circuit_u: QuantumCircuit = circuit_u
-        self._bitstrings_u: list[tuple[int, ...]] = bitstrings_u
-        self._bitstrings_v: list[tuple[int, ...]] = bitstrings_v or bitstrings_u
+        self.circuit_u: QuantumCircuit = circuit_u
+        self.bitstrings_u: list[tuple[int, ...]] = bitstrings_u
+        self.bitstrings_v: list[tuple[int, ...]] = bitstrings_v or bitstrings_u
 
     @property
     def circuit_u(self) -> QuantumCircuit:
@@ -101,21 +101,21 @@ class EntanglementForgingAnsatz:
     @property
     def bitstrings_are_symmetric(self) -> bool:
         """Property function for the symmetry of bitstrings."""
-        return self._bitstrings_v == self._bitstrings_u
+        return self.bitstrings_v == self.bitstrings_u
 
     @property
     def subspace_dimension(self) -> int:
         """Property function for the length of bitstrings."""
-        return len(self._bitstrings_u)
+        return len(self.bitstrings_u)
 
     def __repr__(self) -> str:
         """Representation function for EntanglementForgingAnsatz."""
         repr = "EntanglementForgingAnsatz\nCircuit:\n"
-        repr += str(self._circuit_u.draw())
+        repr += str(self.circuit_u.draw())
         repr += "\nBitstrings U:\n"
         repr += str(self.bitstrings_u)
         repr += "\nBitstrings V:\n"
-        repr += str(self._bitstrings_v)
+        repr += str(self.bitstrings_v)
         repr += f"\nBitstring are symmetric: {self.bitstrings_are_symmetric}\n"
         repr += f"Subspace dimension: {self.subspace_dimension}"
         return repr

--- a/circuit_knitting/forging/entanglement_forging_ansatz.py
+++ b/circuit_knitting/forging/entanglement_forging_ansatz.py
@@ -79,9 +79,9 @@ class EntanglementForgingAnsatz:
                     "There must be the same number of V bitstrings as U bitstrings."
                 )
 
-        self.circuit_u: QuantumCircuit = circuit_u
-        self.bitstrings_u: list[tuple[int, ...]] = bitstrings_u
-        self.bitstrings_v: list[tuple[int, ...]] = bitstrings_v or bitstrings_u
+        self._circuit_u: QuantumCircuit = circuit_u
+        self._bitstrings_u: list[tuple[int, ...]] = bitstrings_u
+        self._bitstrings_v: list[tuple[int, ...]] = bitstrings_v or bitstrings_u
 
     @property
     def circuit_u(self) -> QuantumCircuit:

--- a/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
+++ b/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
@@ -82,8 +82,8 @@ class EntanglementForgingResult(EigenstateResult):
     def __init__(self) -> None:
         """Initialize `EigenstateResult` parent class and set class fields."""
         super().__init__()
-        self._energy_shift: float = 0.0
-        self._history: list[EntanglementForgingEvaluation] = []
+        self.energy_shift: float = 0.0
+        self.history: list[EntanglementForgingEvaluation] = []
 
     @property
     def history(self) -> list[EntanglementForgingEvaluation]:
@@ -151,14 +151,14 @@ class EntanglementForgingGroundStateSolver:
         self._knitter: EntanglementForgingKnitter | None = None
         self._history: EntanglementForgingHistory = EntanglementForgingHistory()
         self._energy_shift = 0.0
-        self._ansatz: EntanglementForgingAnsatz | None = ansatz
-        self._service: QiskitRuntimeService | None = service
-        self._initial_point: np.ndarray | None = initial_point
-        self._orbitals_to_reduce = orbitals_to_reduce
+        self.ansatz: EntanglementForgingAnsatz | None = ansatz
+        self.service: QiskitRuntimeService | None = service
+        self.initial_point: np.ndarray | None = initial_point
+        self.orbitals_to_reduce = orbitals_to_reduce
         self.backend_names = backend_names  # type: ignore
         self.options = options
-        self._mo_coeff = mo_coeff
-        self._optimizer: Optimizer | MINIMIZER = optimizer or SPSA()
+        self.mo_coeff = mo_coeff
+        self.optimizer: Optimizer | MINIMIZER = optimizer or SPSA()
 
     @property
     def ansatz(self) -> EntanglementForgingAnsatz | None:
@@ -263,39 +263,39 @@ class EntanglementForgingGroundStateSolver:
                 incompatible lengths
             AttributeError: Ansatz must be set before calling `solve` method
         """
-        if self._backend_names and self._options:
-            if len(self._backend_names) != len(self._options):
-                if len(self._options) == 1:
-                    self._options = [self._options[0]] * len(self._backend_names)
+        if self.backend_names and self.options:
+            if len(self.backend_names) != len(self.options):
+                if len(self.options) == 1:
+                    self.options = [self.options[0]] * len(self.backend_names)
                 else:
                     raise AttributeError(
                         f"The list of backend names is length ({len(self._backend_names)}), "
                         f"but the list of options is length ({len(self._options)}). It is "
                         "ambiguous how to combine the options with the backends."
                     )
-        if self._ansatz is None:
+        if self.ansatz is None:
             raise AttributeError("Ansatz must be set before calling solve.")
-        if self._initial_point is None:
-            self._initial_point = np.array(
-                [0.0 for i in range(len(self._ansatz.circuit_u.parameters))]
+        if self.initial_point is None:
+            self.initial_point = np.array(
+                [0.0 for i in range(len(self.ansatz.circuit_u.parameters))]
             )
 
         # Get the decomposed hamiltonian
         hamiltonian_terms = self.get_qubit_operators(problem)
-        ef_operator = convert_cholesky_operator(hamiltonian_terms, self._ansatz)
+        ef_operator = convert_cholesky_operator(hamiltonian_terms, self.ansatz)
 
         # Set the knitter class field
-        if self._service is not None:
-            backend_names = self._backend_names or ["ibmq_qasm_simulator"]
+        if self.service is not None:
+            backend_names = self.backend_names or ["ibmq_qasm_simulator"]
             self._knitter = EntanglementForgingKnitter(
-                self._ansatz,
-                service=self._service,
+                self.ansatz,
+                service=self.service,
                 backend_names=backend_names,
-                options=self._options,
+                options=self.options,
             )
         else:
             self._knitter = EntanglementForgingKnitter(
-                self._ansatz, options=self._options
+                self.ansatz, options=self.options
             )
         self._history = EntanglementForgingHistory()
         self._eval_count = 0
@@ -303,10 +303,10 @@ class EntanglementForgingGroundStateSolver:
 
         # Minimize the minimum eigenvalue with respect to the ansatz parameters
         start_time = time()
-        if callable(self._optimizer):
-            self.optimizer(fun=evaluate_eigenvalue, x0=self._initial_point)
+        if callable(self.optimizer):
+            self.optimizer(fun=evaluate_eigenvalue, x0=self.initial_point)
         else:
-            self.optimizer.minimize(fun=evaluate_eigenvalue, x0=self._initial_point)
+            self.optimizer.minimize(fun=evaluate_eigenvalue, x0=self.initial_point)
         elapsed_time = time() - start_time
 
         # Find the minimum eigenvalue found during optimization
@@ -376,7 +376,7 @@ class EntanglementForgingGroundStateSolver:
         self._validate_problem_and_coeffs(problem, self.mo_coeff)
 
         hamiltonian_ops, self._energy_shift = cholesky_decomposition(
-            problem, self.mo_coeff, self._orbitals_to_reduce  # type: ignore
+            problem, self.mo_coeff, self.orbitals_to_reduce  # type: ignore
         )
         return hamiltonian_ops
 

--- a/circuit_knitting/forging/entanglement_forging_knitter.py
+++ b/circuit_knitting/forging/entanglement_forging_knitter.py
@@ -65,7 +65,7 @@ class EntanglementForgingKnitter:
         self._service = service.active_account() if service is not None else service
 
         # Save the parameterized ansatz and bitstrings
-        self.ansatz: EntanglementForgingAnsatz = EntanglementForgingAnsatz(
+        self._ansatz: EntanglementForgingAnsatz = EntanglementForgingAnsatz(
             circuit_u=ansatz.circuit_u,
             bitstrings_u=ansatz.bitstrings_u,
             bitstrings_v=ansatz.bitstrings_v or ansatz.bitstrings_u,

--- a/circuit_knitting/forging/entanglement_forging_knitter.py
+++ b/circuit_knitting/forging/entanglement_forging_knitter.py
@@ -58,7 +58,7 @@ class EntanglementForgingKnitter:
         # Call backend_names setter to update the session_ids hidden class field
         self._session_ids: list[str | None] | None = None
         # Call constructors
-        self.backend_names = backend_names  # type: ignore
+        self.backend_names = backend_names # type: ignore
         self.options = options
 
         # The service hidden class field is a json representing the QiskitRuntimeService object
@@ -112,7 +112,7 @@ class EntanglementForgingKnitter:
         if isinstance(backend_names, str):
             self._backend_names = [backend_names]
         else:
-            self._backend_names = backend_names
+            self._backend_names = backend_names # type: ignore
         if backend_names:
             self._session_ids = [None] * len(backend_names)
 
@@ -127,7 +127,7 @@ class EntanglementForgingKnitter:
         if isinstance(options, Options):
             self._options = [options]
         else:
-            self._options = options
+            self._options = options # type: ignore
 
     @property
     def service(self) -> QiskitRuntimeService | None:

--- a/circuit_knitting/forging/entanglement_forging_knitter.py
+++ b/circuit_knitting/forging/entanglement_forging_knitter.py
@@ -58,7 +58,7 @@ class EntanglementForgingKnitter:
         # Call backend_names setter to update the session_ids hidden class field
         self._session_ids: list[str | None] | None = None
         # Call constructors
-        self.backend_names = backend_names # type: ignore
+        self.backend_names = backend_names  # type: ignore
         self.options = options
 
         # The service hidden class field is a json representing the QiskitRuntimeService object
@@ -112,7 +112,7 @@ class EntanglementForgingKnitter:
         if isinstance(backend_names, str):
             self._backend_names = [backend_names]
         else:
-            self._backend_names = backend_names # type: ignore
+            self._backend_names = backend_names  # type: ignore
         if backend_names:
             self._session_ids = [None] * len(backend_names)
 
@@ -127,7 +127,7 @@ class EntanglementForgingKnitter:
         if isinstance(options, Options):
             self._options = [options]
         else:
-            self._options = options # type: ignore
+            self._options = options  # type: ignore
 
     @property
     def service(self) -> QiskitRuntimeService | None:


### PR DESCRIPTION
We have generally used the private class fields within class methods, rather than using the getters, but this is causing unnecessary dropped coverage in EF. This PR switches the EF modules to use getters/setters internally, in order to get credit for that code coverage.