### PR TITLE
improve ObservableCollection.lookup docstring

### DIFF
--- a/circuit_knitting/utils/observable_grouping.py
+++ b/circuit_knitting/utils/observable_grouping.py
@@ -258,7 +258,7 @@ class ObservableCollection:
 
     @property
     def lookup(self) -> dict[Pauli, list[tuple[int, int]]]:
-        r"""Get dict which maps each :class:`~qiskit.quantum_info.Pauli` observable to a list of indices, (i, j), to commuting observables in ``groups``.
+        r"""Get dict which maps each :class:`~qiskit.quantum_info.Pauli` observable to a list of indices, ``(i, j)``, to commuting observables in ``groups``.
 
         For each element of the list, it means that the :class:`~qiskit.quantum_info.Pauli` is given by
         the ``j``th commuting observable in the ``i``th group.

--- a/circuit_knitting/utils/observable_grouping.py
+++ b/circuit_knitting/utils/observable_grouping.py
@@ -258,7 +258,7 @@ class ObservableCollection:
 
     @property
     def lookup(self) -> dict[Pauli, list[tuple[int, int]]]:
-        r"""Get dict which maps each :class:`~qiskit.quantum_info.Pauli` observable to a list of commuting observables in ``groups``.
+        r"""Get dict which maps each :class:`~qiskit.quantum_info.Pauli` observable to a list of indices to commuting observables in ``groups``.
 
         For each element of the list, it means that the :class:`~qiskit.quantum_info.Pauli` is given by
         the ``j``th commuting observable in the ``i``th group.

--- a/circuit_knitting/utils/observable_grouping.py
+++ b/circuit_knitting/utils/observable_grouping.py
@@ -258,7 +258,7 @@ class ObservableCollection:
 
     @property
     def lookup(self) -> dict[Pauli, list[tuple[int, int]]]:
-        r"""Get dict which maps each :class:`~qiskit.quantum_info.Pauli` observable to a list of indices to commuting observables in ``groups``.
+        r"""Get dict which maps each :class:`~qiskit.quantum_info.Pauli` observable to a list of indices, (i, j), to commuting observables in ``groups``.
 
         For each element of the list, it means that the :class:`~qiskit.quantum_info.Pauli` is given by
         the ``j``th commuting observable in the ``i``th group.

--- a/circuit_knitting/utils/observable_grouping.py
+++ b/circuit_knitting/utils/observable_grouping.py
@@ -258,7 +258,7 @@ class ObservableCollection:
 
     @property
     def lookup(self) -> dict[Pauli, list[tuple[int, int]]]:
-        r"""Get dict which maps each :class:`~qiskit.quantum_info.Pauli` observable to a list of ``(i, j)`` pairs.
+        r"""Get dict which maps each :class:`~qiskit.quantum_info.Pauli` observable to a list of commuting observables in ``groups``.
 
         For each element of the list, it means that the :class:`~qiskit.quantum_info.Pauli` is given by
         the ``j``th commuting observable in the ``i``th group.


### PR DESCRIPTION
`ckt.utils.observable_grouping.ObservableCollection.lookup` docstring intro sentence reads a little vague in the API. Adding a little context to the intro sentence of docstring to make API more clear