### PR TITLE
Cplex is now compatible with Python 3.11

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -47,10 +47,6 @@ jobs:
           pver=${{ matrix.python-version }}
           tox -epy${pver/./} -- --run-slow
           notebook_flags=""
-          if [ "$pver" = "3.11" ]; then
-            echo Skipping tutorials that require cplex
-            notebook_flags="${notebook_flags} --ignore=docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb --ignore=docs/circuit_cutting/cutqc/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb"
-          fi
           if [ "$RUNNER_OS" = "Windows" ]; then
             echo Skipping tutorials \& how-tos that require pyscf
             notebook_flags="${notebook_flags} --ignore=docs/entanglement_forging --ignore=docs/_build/jupyter_execute/entanglement_forging/how-tos"

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -185,8 +185,7 @@ take care when installing the toolbox, depending on which tools they
 intend to use.
   
   - The automatic wire cut search in the ``cutqc`` package depends
-    on CPLEX, which is only available on Intel chips and is not yet available
-    for Python 3.11.
+    on CPLEX, which is only available on Intel chips.
   - The entanglement forging tool requires PySCF, which does not support Windows.
 
 In each case, one method that is guaranteed to work is to :ref:`use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ dependencies = [
 cplex = [
     # We use the same restrictions in both of the following lines, as there
     # is no reason for us to install docplex without cplex.
-    "docplex>=2.23.222; python_version < '3.11' and platform_machine != 'arm64'",
-    "cplex>=22.1.0.0; python_version < '3.11' and platform_machine != 'arm64'",
+    "docplex>=2.23.222; platform_machine != 'arm64'",
+    "cplex>=22.1.0.0; platform_machine != 'arm64'",
 ]
 pyscf = [
     "pyscf>=2.0.1; sys_platform != 'win32'",


### PR DESCRIPTION
There are new cplex binaries for Python 3.11, so we can run all our tests on Python 3.11 now.

Ref https://github.com/qiskit-community/qiskit-optimization/pull/533