### PR TITLE
Shorten the section names in the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,18 +40,18 @@ Contents
   :maxdepth: 2
   :caption: Circuit Cutting
 
-  Circuit Cutting Tutorials <circuit_cutting/tutorials/index>
-  Circuit Cutting Explanatory Material <circuit_cutting/explanation/index>
-  Circuit Cutting How-To Guides <circuit_cutting/how-tos/index>
+  Cutting Tutorials <circuit_cutting/tutorials/index>
+  Cutting Explanatory Material <circuit_cutting/explanation/index>
+  Cutting How-To Guides <circuit_cutting/how-tos/index>
   CutQC (legacy circuit cutting implementation) <circuit_cutting/cutqc/index>
 
 .. toctree::
   :maxdepth: 2
   :caption: Entanglement Forging
 
-  Entanglement Forging Tutorials <entanglement_forging/tutorials/index>
-  Entanglement Forging Explanatory Material <entanglement_forging/explanation/index>
-  Entanglement Forging How-To Guides <entanglement_forging/how-tos/index>
+  Forging Tutorials <entanglement_forging/tutorials/index>
+  Forging Explanatory Material <entanglement_forging/explanation/index>
+  Forging How-To Guides <entanglement_forging/how-tos/index>
 
 .. toctree::
   :maxdepth: 2


### PR DESCRIPTION
I find the new one much easier to scan.

Old:
![old-sidebar](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/assets/91987/88bbcef1-59b6-4610-b51a-01ded1ce8492)

New:
![new-sidebar](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/assets/91987/d2bbb3ab-5b24-45b0-9910-ade70fc6f6e6)
