### PR TITLE
Migrate to Docker Compose V2

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,4 +38,4 @@ This workflow is triggered by a maintainer pushing a tag that represents a relea
 
 ## Docker (`docker.yml`)
 
-This workflow runs periodically (weekly, at the time of writing) to ensure that the [`Dockerfile`](/Dockerfile) and [`docker-compose.yml`](/docker-compose.yml) files at the root of the repository result in a successful build with notebooks that execute without error.
+This workflow runs periodically (weekly, at the time of writing) to ensure that the [`Dockerfile`](/Dockerfile) and [`compose.yaml`](/compose.yaml) files at the root of the repository result in a successful build with notebooks that execute without error.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,4 +20,4 @@ jobs:
         run: docker compose build
       - name: Test notebooks
         shell: bash
-        run: docker compose run notebook "bash" "-c" "pip install pytest nbmake && pytest --nbmake docs --ignore=docs/entanglement_forging/tutorials/tutorial_2_forging_with_quantum_serverless.ipynb"
+        run: docker compose run notebook "bash" "-c" "pip install pytest nbmake && pytest --nbmake docs --ignore=docs/circuit-knitting-toolbox/entanglement_forging/tutorials/tutorial_2_forging_with_quantum_serverless.ipynb"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,10 +3,10 @@ name: Docker notebook tests
 on:
   push:
     branches: [ main ]
-    paths: ['Dockerfile', '.dockerignore', 'docker-compose.yml']
+    paths: ['Dockerfile', '.dockerignore', 'compose.yaml']
   pull_request:
     branches: [ main ]
-    paths: ['Dockerfile', '.dockerignore', 'docker-compose.yml']
+    paths: ['Dockerfile', '.dockerignore', 'compose.yaml']
   schedule:
     - cron: '0 20 * * 3'
 
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build image
-        run: docker-compose build
+        run: docker compose build
       - name: Test notebooks
         shell: bash
-        run: docker-compose run notebook "bash" "-c" "pip install pytest nbmake && pytest --nbmake docs"
+        run: docker compose run notebook "bash" "-c" "pip install pytest nbmake && pytest --nbmake docs"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,4 +20,4 @@ jobs:
         run: docker compose build
       - name: Test notebooks
         shell: bash
-        run: docker compose run notebook "bash" "-c" "pip install pytest nbmake && pytest --nbmake docs"
+        run: docker compose run notebook "bash" "-c" "pip install pytest nbmake && pytest --nbmake docs --ignore=docs/entanglement_forging/tutorials/tutorial_2_forging_with_quantum_serverless.ipynb"

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -122,21 +122,18 @@ Option 3: Use within Docker
 
 We have provided a `Dockerfile <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/main/Dockerfile>`__, which can be used to
 build a Docker image, as well as a
-`docker-compose.yml <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/main/docker-compose.yml>`__ file, which allows one
-to use the Docker image with just a few simple commands. If you have
-Docker installed but not `Docker
-Compose <https://pypi.org/project/docker-compose/>`__, the latter can be
-installed by first running ``pip install docker-compose``.
+`compose.yaml <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/main/compose.yaml>`__ file, which allows one
+to use the Docker image with just a few simple commands.
 
 .. code:: sh
 
     git clone git@github.com:Qiskit-Extensions/circuit-knitting-toolbox.git
     cd circuit-knitting-toolbox
-    docker-compose build
-    docker-compose up
+    docker compose build
+    docker compose up
 
 Depending on your system configuration, you may need to type ``sudo``
-before each ``docker-compose`` command.
+before each ``docker compose`` command.
 
 .. note::
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   notebook:
     build: .


### PR DESCRIPTION
From https://docs.docker.com/compose/migrate/:

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.
>
> [...]
>
> Unlike Compose V1, Compose V2 integrates into the Docker CLI platform and the recommended command-line syntax is `docker compose`.

From https://docs.docker.com/compose/compose-file/03-compose-file/:

> The default path for a Compose file is `compose.yaml` (preferred) or `compose.yml` that is placed in the working directory. Compose also supports `docker-compose.yaml` and `docker-compose.yml` for backwards compatibility of earlier versions.

From https://github.com/compose-spec/compose-spec/blob/master/spec.md:

> The top-level `version` property is defined by the Compose Specification for backward compatibility. It is only informative.

hence the removal of `version` from the yaml file.