### PR TITLE
Switch to Qiskit Ecosystem theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,8 @@ pygments_style = "colorful"
 add_module_names = False
 modindex_common_prefix = ["circuit_knitting."]
 
-html_theme = "qiskit"
+html_theme = "qiskit-ecosystem"
+html_title = f"{project} {release}"
 
 # autodoc/autosummary options
 autosummary_generate = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ docs = [
     "nbsphinx>=0.8.8",
     "sphinx-copybutton>=0.5.0",
     "reno>=3.4.0",
-    "qiskit-sphinx-theme~=1.13.0rc2"
+    "qiskit-sphinx-theme~=1.14.0rc1"
 ]
 notebook-dependencies = [
     "circuit-knitting-toolbox[cplex,pyscf]",


### PR DESCRIPTION
The main changes are:

1. Gets rid of the top Qiskit nav bar.
2. Adds the project name and Qiskit Ecosystem logo to the left sidebar. (You can disable the logo or replace it with your own)