### PR TITLE
Bump Python version in Dockerfile to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/minimal-notebook:python-3.10
+FROM jupyter/minimal-notebook:python-3.11
 
 LABEL maintainer="Jim Garrison <garrison@ibm.com>"
 


### PR DESCRIPTION
Now that CKT supports Python 3.11, we might as well use the latest version in the Dockerfile.