### PR TITLE
Fix formatting of example in `reduce_bitstrings` docstring

### DIFF
--- a/circuit_knitting/utils/orbital_reduction.py
+++ b/circuit_knitting/utils/orbital_reduction.py
@@ -31,6 +31,7 @@ def reduce_bitstrings(bitstrings, orbitals_to_reduce):
     elements of the bitstrings.
 
     Example:
+
     >>> reduce_bitstrings([[1, 0, 0, 1, 0], [1, 0, 0, 0, 1], [1, 1, 1, 1, 0]], [0, 1])
     [(0, 1, 0), (0, 0, 1), (1, 1, 0)]
 


### PR DESCRIPTION
This fixes the formatting of the example at https://qiskit-extensions.github.io/circuit-knitting-toolbox/stubs/circuit_knitting_toolbox.utils.orbital_reduction.reduce_bitstrings.html#circuit_knitting_toolbox.utils.orbital_reduction.reduce_bitstrings.

I verified this locally.

I plan to merge once tests pass.