### PR TITLE
Make the repository link more obvious from the Sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,9 @@ html_theme_options = {
             "class": "",
         },
     ],
+    "source_repository": "https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/",
+    "source_branch": "main",
+    "source_directory": "docs/",
 }
 
 # autodoc/autosummary options

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,20 @@ modindex_common_prefix = ["circuit_knitting."]
 
 html_theme = "qiskit-ecosystem"
 html_title = f"{project} {release}"
+html_theme_options = {
+    "footer_icons": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/Qiskit-Extensions/circuit-knitting-toolbox",
+            "html": """
+                <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+                </svg>
+            """,
+            "class": "",
+        },
+    ],
+}
 
 # autodoc/autosummary options
 autosummary_generate = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ html_theme = "qiskit-ecosystem"
 html_title = f"{project} {release}"
 html_theme_options = {
     "footer_icons": [
+        # https://pradyunsg.me/furo/customisation/footer/#using-embedded-svgs
         {
             "name": "GitHub",
             "url": "https://github.com/Qiskit-Extensions/circuit-knitting-toolbox",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,8 +11,6 @@ The toolbox currently contains the following tools:
 - Circuit Cutting
 - Entanglement Forging
 
-The source code to the toolbox is available `on GitHub <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox>`_.
-
 .. note::
 
    The `Quantum Serverless <https://qiskit-extensions.github.io/quantum-serverless/>`_ framework is documented separately, as it lives in its own repository.  Check out `Entanglement Forging Tutorial 2: Forging with Quantum Serverless <./entanglement_forging/tutorials/tutorial_2_forging_with_quantum_serverless.ipynb>`_  and `CutQC Tutorial 3: Circuit Cutting with Quantum Serverless <./circuit_cutting/tutorials/cutqc/tutorial_3_cutting_with_quantum_serverless.ipynb>`_ for examples on how to integrate Quantum Serverless into circuit knitting workflows.
@@ -29,6 +27,8 @@ If you use the Circuit Knitting Toolbox in your research, please cite it accordi
 
 Developer guide
 ---------------
+
+The source code to the toolbox is available `on GitHub <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox>`__.
 
 The developer guide is located at `CONTRIBUTING.md <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/main/CONTRIBUTING.md>`__ in the root of this project's repository.
 


### PR DESCRIPTION
This PR does two things to make the repository more discoverable from the Sphinx build
- moves the mention of the GitHub repository to the section titled "Developer guide"
- adds a GitHub icon in the footer of each page, which links to the repo, following the instructions at https://pradyunsg.me/furo/customisation/footer/#using-embedded-svgs

#### Screenshot of the footer (see bottom right corner)
![furo-github-footer](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/assets/91987/2a65363a-31c9-4233-a5e7-4790ae83bf00)
