### PR TITLE
Pin black's major version only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ nbtest = [
 ]
 style = [
     "autoflake==2.2.0",
-    "black[jupyter]==23.3.0",
+    "black[jupyter]~=23.1",
     "ruff>=0.0.246",
     "nbqa>=1.6.0",
 ]


### PR DESCRIPTION
black advertises that there should be no breaking changes during a stable version series.  If we merge this, we will reduce some dependabot noise (a few times per year).

Alternative to #343.