### PR TITLE
Fix sphinx build by depending on ipykernel directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ docs = [
     "sphinx-autodoc-typehints>=1.12.0",
     "sphinx-reredirects",
     "jupyter-sphinx>=0.3.2",
+    # The following line is needed until
+    # https://github.com/jupyter/jupyter-sphinx/pull/226 is resolved.
+    "ipykernel>=4.5.1",
     "nbsphinx>=0.8.8",
     "sphinx-copybutton>=0.5.0",
     "reno>=3.4.0",


### PR DESCRIPTION
This adds a dependency on ipykernel, the lack of which caused CI failures in #343 and #344.   https://github.com/jupyter/jupyter-sphinx/pull/226 is my attempt to "fix" this upstream.