### PR TITLE
Fix description of `partition_problem` in wire cutting tutorial

### DIFF
--- a/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
+++ b/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
@@ -235,10 +235,11 @@
    "id": "fd0b0d6c-de39-459c-8b97-6831dab6b3be",
    "metadata": {},
    "source": [
-    "`execute_experiments` returns:\n",
+    "`partition_problem` returns:\n",
     "\n",
-    "- A 3D list of length-2 tuples containing a quasiprobability distribution and QPD bit information for each unique subexperiment\n",
-    "- The coefficients for each subexperiment"
+    "- `Dict` mapping partition labels to subcircuits\n",
+    "- `Dict` mapping partition labels to subobservables\n",
+    "- A `list` of  ``QPDBasis`` instances, one for each decomposed instruction"
    ]
   },
   {


### PR DESCRIPTION
This is a follow-up to #174.  In that PR, `partition_problem` was not described, but `execute_experiments` was mistakenly described in two locations.