### PR TITLE
Fix `partition_problem`'s handling of unlabeled `TwoQubitQPDGate`s

### DIFF
--- a/circuit_knitting/cutting/cutting_decomposition.py
+++ b/circuit_knitting/cutting/cutting_decomposition.py
@@ -223,7 +223,7 @@ def partition_problem(
     for inst in qpd_circuit.data:
         if isinstance(inst.operation, TwoQubitQPDGate):
             bases.append(inst.operation.basis)
-            inst.operation.label = inst.operation.label + f"_{i}"
+            inst.operation.label = f"{inst.operation.label}_{i}"
             i += 1
 
     # Separate the decomposed circuit into its subcircuits

--- a/test/cutting/test_cutting_decomposition.py
+++ b/test/cutting/test_cutting_decomposition.py
@@ -26,6 +26,7 @@ from circuit_knitting.cutting import (
     partition_problem,
     cut_gates,
 )
+from circuit_knitting.cutting.instructions import Move
 from circuit_knitting.cutting.qpd import (
     QPDBasis,
     TwoQubitQPDGate,
@@ -218,11 +219,27 @@ class TestCuttingDecomposition(unittest.TestCase):
             observable = PauliList(["-ZZXX"])
 
             with pytest.raises(ValueError) as e_info:
-                partition_problem(circuit, partition_labels, observables=observable)
+                partition_problem(
+                    self.circuit, partition_labels, observables=observable
+                )
             assert (
                 e_info.value.args[0]
                 == "An input observable has a phase not equal to 1."
             )
+        with self.subTest("Unlabeled TwoQubitQPDGates (smoke test)"):
+            qc = QuantumCircuit(4)
+            qc.rx(np.pi / 4, 0)
+            qc.rx(np.pi / 4, 1)
+            qc.rx(np.pi / 4, 3)
+            qc.cx(0, 1)
+            qc.append(TwoQubitQPDGate(QPDBasis.from_gate(Move())), [1, 2])
+            qc.cx(2, 3)
+            qc.append(TwoQubitQPDGate(QPDBasis.from_gate(Move())), [2, 1])
+            qc.cx(0, 1)
+            subcircuits, bases, subobservables = partition_problem(
+                qc, "AABB", observables=PauliList(["IZIZ"])
+            )
+            assert len(subcircuits) == len(bases) == len(subobservables) == 2
 
     def test_cut_gates(self):
         with self.subTest("simple circuit"):


### PR DESCRIPTION
I noticed when experimenting with `partition_problem` that it blows up if you give it a circuit that contains an unlabeled `TwoQubitQPDGate`.  In our workflows so far, all `TwoQubitQPDGate`s are created within `partition_problem` itself, as the first thing it does is call `partition_circuit_qubits`, which creates the gates with the labels.  However, it's not strictly necessary for the gates to have labels, and people might want to place some `TwoQubitQPDGates` manually in addition to the ones across the partition labels.  (Also, in the future, we might want to make `partition_labels` optional, at which point it will just partition as well as it can using the `TwoQubitQPDGates` that have been placed.)

I double checked, and the added test indeed fails without the accompanying change.