### PR TITLE
Update language in cutting tutorials

### DIFF
--- a/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
+++ b/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "- **cut** some non-local gates in the circuit and possibly separate the circuit into subcircuits\n",
     "- **execute** many sampled subexperiments on the backend(s)\n",
-    "- **reconstruct** the simulated expectation value of the full-sized circuit"
+    "- **reconstruct** the expectation value of the full-sized circuit"
    ]
   },
   {
@@ -280,7 +280,7 @@
    "id": "f0032570",
    "metadata": {},
    "source": [
-    "### Reconstruct the simulated expectation values\n",
+    "### Reconstruct the expectation values\n",
     "`reconstruct_expectation_values` expects `quasi_dists` and `coefficients` in the same format as returned from `execute_experiments`. `quasi_dists` is a 3D list of shape (`num_unique_samples`, `num_partitions`, `num_commuting_observ_groups`), and `coefficients` is a list with length equal to the number of unique samples. `subobservables` is the dictionary mapping qubit partition label to the associated subobservable(s), as output from `decompose_problem` above."
    ]
   },
@@ -291,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulated_expvals = reconstruct_expectation_values(\n",
+    "reconstructed_expvals = reconstruct_expectation_values(\n",
     "    quasi_dists,\n",
     "    coefficients,\n",
     "    subobservables,\n",
@@ -303,7 +303,7 @@
    "id": "b546c0c4",
    "metadata": {},
    "source": [
-    "The output of `reconstruct_expectation_values` is a list of simulated expectation values -- one for each observable."
+    "The output of `reconstruct_expectation_values` is a list of expectation values -- one for each observable."
    ]
   },
   {
@@ -311,7 +311,7 @@
    "id": "53beaca3",
    "metadata": {},
    "source": [
-    "### Compare the simulated expectation values with the exact expectation values from the original circuit"
+    "### Compare the reconstructed expectation values with the exact expectation values from the original circuit"
    ]
   },
   {
@@ -337,16 +337,16 @@
     "    estimator.run([circuit] * len(observables), list(observables)).result().values\n",
     ")\n",
     "print(\n",
-    "    f\"Simulated expectation values: {[np.round(simulated_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
+    "    f\"Reconstructed expectation values: {[np.round(reconstructed_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
     ")\n",
     "print(\n",
     "    f\"Exact expectation values: {[np.round(exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
     ")\n",
     "print(\n",
-    "    f\"Errors in estimation: {[np.round(simulated_expvals[i]-exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
+    "    f\"Errors in estimation: {[np.round(reconstructed_expvals[i]-exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
     ")\n",
     "print(\n",
-    "    f\"Relative errors in estimation: {[np.round((simulated_expvals[i]-exact_expvals[i]) / exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
+    "    f\"Relative errors in estimation: {[np.round((reconstructed_expvals[i]-exact_expvals[i]) / exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
     ")"
    ]
   },

--- a/docs/circuit_cutting/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
+++ b/docs/circuit_cutting/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "- **decompose** some non-local gates in the circuit and possibly separate the circuit into subcircuits\n",
     "- **execute** many sampled subexperiments on the backend(s)\n",
-    "- **reconstruct** the simulated expectation value of the full-sized circuit"
+    "- **reconstruct** the expectation value of the full-sized circuit"
    ]
   },
   {
@@ -233,7 +233,7 @@
    "source": [
     "### Demonstrate that the QPD subexperiments will be shallower after cutting distant gates\n",
     "\n",
-    "Here is an example of an arbitrarily chosen subexperiment generated from the QPD circuit. Its depth has been reduced by more than half. Many of these probabilistic subexperiments must be generated and evaluated in order to reconstruct a simulated expectation value of the deeper circuit."
+    "Here is an example of an arbitrarily chosen subexperiment generated from the QPD circuit. Its depth has been reduced by more than half. Many of these probabilistic subexperiments must be generated and evaluated in order to reconstruct an expectation value of the deeper circuit."
    ]
   },
   {
@@ -333,7 +333,7 @@
    "id": "319c25d7",
    "metadata": {},
    "source": [
-    "### Reconstruct the simulated expectation values\n",
+    "### Reconstruct the expectation values\n",
     "\n",
     "`reconstruct_expectation_values` expects `quasi_dists` and `coefficients` in the same format as returned from `execute_experiments`. `quasi_dists` is a 3D list of shape (`num_unique_samples`, `num_partitions`, `num_commuting_observ_groups`), and `coefficients` is a list with length equal to the number of unique samples. `subobservables` is the dictionary mapping qubit partition label to the associated subobservable(s). The decomposition of this circuit did not result in separation into subcircuits, so there will be only one partition represented in these outputs."
    ]
@@ -345,7 +345,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulated_expvals = reconstruct_expectation_values(\n",
+    "reconstructed_expvals = reconstruct_expectation_values(\n",
     "    quasi_dists,\n",
     "    coefficients,\n",
     "    observables,\n",
@@ -357,7 +357,7 @@
    "id": "433e1707",
    "metadata": {},
    "source": [
-    "The output of `reconstruct_expectation_values` is a list of simulated expectation values -- one for each observable."
+    "The output of `reconstruct_expectation_values` is a list of expectation values reconstructed from the smaller subexperiments -- one for each observable."
    ]
   },
   {
@@ -365,7 +365,7 @@
    "id": "3fc2327f",
    "metadata": {},
    "source": [
-    "### Compare simulated expectation values to exact expectation values from the original circuit"
+    "### Compare reconstructed expectation values to exact expectation values from the original circuit"
    ]
   },
   {
@@ -391,16 +391,16 @@
     "    estimator.run([circuit] * len(observables), list(observables)).result().values\n",
     ")\n",
     "print(\n",
-    "    f\"Simulated expectation values: {[np.round(simulated_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
+    "    f\"Reconstructed expectation values: {[np.round(reconstructed_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
     ")\n",
     "print(\n",
     "    f\"Exact expectation values: {[np.round(exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
     ")\n",
     "print(\n",
-    "    f\"Errors in estimation: {[np.round(simulated_expvals[i]-exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
+    "    f\"Errors in estimation: {[np.round(reconstructed_expvals[i]-exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
     ")\n",
     "print(\n",
-    "    f\"Relative errors in estimation: {[np.round((simulated_expvals[i]-exact_expvals[i]) / exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
+    "    f\"Relative errors in estimation: {[np.round((reconstructed_expvals[i]-exact_expvals[i]) / exact_expvals[i], 8) for i in range(len(exact_expvals))]}\"\n",
     ")"
    ]
   },

--- a/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
+++ b/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "- **cut** some wires in the circuit and possibly separate the circuit into subcircuits\n",
     "- **execute** many sampled subexperiments on the backend(s)\n",
-    "- **reconstruct** the simulated expectation value of the full-sized circuit"
+    "- **reconstruct** the expectation value of the full-sized circuit"
    ]
   },
   {
@@ -389,7 +389,7 @@
    "id": "5c5fdec5-89ed-480f-833f-7377c33ad365",
    "metadata": {},
    "source": [
-    "### Reconstruct the simulated expectation values\n",
+    "### Reconstruct the expectation values\n",
     "\n",
     "`reconstruct_expectation_values` expects `quasi_dists` and `coefficients` in the same format as returned from `execute_experiments`. `quasi_dists` is a 3D list of shape (`num_unique_samples`, `num_partitions`, `num_commuting_observ_groups`), and `coefficients` is a list with length equal to the number of unique samples. `subobservables` is the dictionary mapping qubit partition label to the associated subobservable(s), as output from `decompose_problem` above."
    ]


### PR DESCRIPTION
Resolves #280

Say reconstruct instead of simulate, to avoid confusion between QPD simulation and backend simulators