### PR TITLE
Use multiple samplers sometimes in the roundtrip tests

### DIFF
--- a/test/cutting/test_cutting_roundtrip.py
+++ b/test/cutting/test_cutting_roundtrip.py
@@ -150,15 +150,18 @@ def test_cutting_exact_reconstruction(example_circuit):
     exact_expvals = (
         estimator.run([qc0] * len(observables), list(observables)).result().values
     )
-    sampler = ExactSampler()
     subcircuits, bases, subobservables = partition_problem(
         qc, "AAB", observables=observables_nophase
     )
+    if np.random.randint(2):
+        samplers = ExactSampler()
+    else:
+        samplers = {label: ExactSampler() for label in subcircuits.keys()}
     quasi_dists, coefficients = execute_experiments(
         circuits=subcircuits,
         subobservables=subobservables,
         num_samples=np.inf,
-        samplers=sampler,
+        samplers=samplers,
     )
     simulated_expvals = reconstruct_expectation_values(
         quasi_dists, coefficients, subobservables


### PR DESCRIPTION
This is my PR promised at https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/pull/333#pullrequestreview-1577702611.

Essentially, I really want the roundtrip tests to regularly test both experiment workflows: the one that uses a single sampler, and the one that uses multiple samplers.  Of course, all sampler(s) used should be `ExactSampler`s, and the expectation values are required to work out exactly, up to floating point error.

This PR achieves this by flipping a coin each time a roundtrip test is called.