### PR TITLE
Use the same number of clbits for all subexperiments generated from a given subcircuit

### DIFF
--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -1135,9 +1135,12 @@ def _decompose_qpd_instructions(
         data_id_offset += 1
         circuit.data.insert(i + data_id_offset, inst2)
 
+
+    # The number of clbits in the "qpd_measurements` register will equal the total
+    # number of decompositions in the input circuit.
+    num_qpd_bits = 0
     # Decompose all the QPDGates (should all be single qubit now) into Qiskit operations
     new_instruction_ids = []
-    num_qpd_bits = 0
     for i, inst in enumerate(circuit.data):
         if isinstance(inst.operation, SingleQubitQPDGate):
             num_qpd_bits += 1

--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -69,7 +69,7 @@ from qiskit.quantum_info.synthesis.two_qubit_decompose import TwoQubitWeylDecomp
 from qiskit.utils import deprecate_func
 
 from .qpd_basis import QPDBasis
-from .instructions import BaseQPDGate, TwoQubitQPDGate, QPDMeasure
+from .instructions import BaseQPDGate, SingleQubitQPDGate, TwoQubitQPDGate, QPDMeasure
 from ..instructions import Move
 from ...utils.iteration import unique_by_id, strict_zip
 
@@ -1062,7 +1062,7 @@ def _validate_qpd_instructions(
 
 
 def _decompose_qpd_measurements(
-    circuit: QuantumCircuit, inplace: bool = True
+    circuit: QuantumCircuit, num_qpd_bits: int, inplace: bool = True
 ) -> QuantumCircuit:
     """
     Create mid-circuit measurements.
@@ -1085,7 +1085,7 @@ def _decompose_qpd_measurements(
     # Create a classical register for the qpd measurement results.  This is
     # partly for convenience, partly to work around
     # https://github.com/Qiskit/qiskit-aer/issues/1660.
-    reg = ClassicalRegister(len(qpd_measure_ids), name="qpd_measurements")
+    reg = ClassicalRegister(num_qpd_bits, name="qpd_measurements")
     circuit.add_register(reg)
 
     # Place the measurement instructions
@@ -1137,8 +1137,10 @@ def _decompose_qpd_instructions(
 
     # Decompose all the QPDGates (should all be single qubit now) into Qiskit operations
     new_instruction_ids = []
+    num_qpd_bits = 0
     for i, inst in enumerate(circuit.data):
-        if isinstance(inst.operation, BaseQPDGate):
+        if isinstance(inst.operation, SingleQubitQPDGate):
+            num_qpd_bits += 1
             new_instruction_ids.append(i)
     data_id_offset = 0
     for i in new_instruction_ids:
@@ -1166,6 +1168,6 @@ def _decompose_qpd_instructions(
             del circuit.data[i + data_id_offset]
             data_id_offset -= 1
 
-    _decompose_qpd_measurements(circuit)
+    _decompose_qpd_measurements(circuit, num_qpd_bits)
 
     return circuit

--- a/releasenotes/notes/num-qpd-bits-779e54dc051caef9.yaml
+++ b/releasenotes/notes/num-qpd-bits-779e54dc051caef9.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+      The ``qpd_measurements`` classical register added to the output of :func:`circuit_knitting.cutting.qpd.decompose_qpd_instructions` will now contain a number of bits based on the number of :class:`circuit_knitting.cutting.qpd.BaseQPDGate` instances in the input circuit, rather than the number of :class:`circuit_knitting.cutting.qpd.QPDMeasure` instances. Now the ``qpd_measurements`` classical register in the output circuit will contain 2 bits for every :class:`circuit_knitting.cutting.qpd.TwoQubitQPDGate` instance and 1 bit for every :class:`Circuit_knitting.cutting.qpd.SingleQubitQPDGate` instance.

--- a/test/cutting/qpd/test_qpd.py
+++ b/test/cutting/qpd/test_qpd.py
@@ -148,7 +148,7 @@ class TestQPDFunctions(unittest.TestCase):
             qpd_gate = TwoQubitQPDGate(qpd_basis)
             circ.data.append(CircuitInstruction(qpd_gate, qubits=[0, 1]))
             decomp_circ = decompose_qpd_instructions(circ, [[0]], map_ids=[0])
-            circ_compare.add_register(ClassicalRegister(0, name="qpd_measurements"))
+            circ_compare.add_register(ClassicalRegister(2, name="qpd_measurements"))
             self.assertEqual(decomp_circ, circ_compare)
         with self.subTest("Incorrect map index size"):
             with pytest.raises(ValueError) as e_info:
@@ -175,7 +175,7 @@ class TestQPDFunctions(unittest.TestCase):
             qpd_inst = CircuitInstruction(self.qpd_gate1, qubits=[0, 1])
             qpd_circ.data.append(qpd_inst)
             dx_circ_truth = QuantumCircuit(2)
-            creg = ClassicalRegister(1, name="qpd_measurements")
+            creg = ClassicalRegister(2, name="qpd_measurements")
             dx_circ_truth.add_register(creg)
             dx_circ_truth.h(0)
             dx_circ_truth.rx(np.pi / 2, 1)

--- a/test/cutting/test_cutting_evaluation.py
+++ b/test/cutting/test_cutting_evaluation.py
@@ -67,7 +67,7 @@ class TestCuttingEvaluation(unittest.TestCase):
             quasi_dists, coefficients = execute_experiments(
                 self.circuit, self.observable, num_samples=50, samplers=self.sampler
             )
-            self.assertEqual([[[(QuasiDistribution({3: 1.0}), 0)]]], quasi_dists)
+            self.assertEqual([[[(QuasiDistribution({12: 1.0}), 2)]]], quasi_dists)
             self.assertEqual([(1.0, WeightType.EXACT)], coefficients)
         with self.subTest("Basic test with dicts"):
             circ1 = QuantumCircuit(1)
@@ -103,8 +103,8 @@ class TestCuttingEvaluation(unittest.TestCase):
             self.assertEqual(
                 [
                     [
-                        [(QuasiDistribution({1: 1.0}), 0)],
-                        [(QuasiDistribution({1: 1.0}), 0)],
+                        [(QuasiDistribution({2: 1.0}), 1)],
+                        [(QuasiDistribution({2: 1.0}), 1)],
                     ]
                 ],
                 quasi_dists,


### PR DESCRIPTION
Reasoning about the quasi-dist outputs from various `Sampler` implementations requires knowing the size of the two classical registers added during cutting -- `observable_measurements` and `qpd_measurements`. Making all of the subexperiments generated from a given subcircuit have the same size `qpd_measurements` creg makes post-processing more straightforward.

This change will be useful in the #363 refactor as well.