### PR TITLE
Avoid unpacking `PartitionedCuttingProblem` in tutorials & how-tos

### DIFF
--- a/docs/circuit_cutting/how-tos/how_to_generate_exact_quasi_dists_from_sampler.ipynb
+++ b/docs/circuit_cutting/how-tos/how_to_generate_exact_quasi_dists_from_sampler.ipynb
@@ -45,9 +45,11 @@
     "circuit.h(0)\n",
     "circuit.cx(0, 1)\n",
     "observables = PauliList([\"ZZ\"])\n",
-    "subcircuits, _, subobservables = partition_problem(\n",
+    "partitioned_problem = partition_problem(\n",
     "    circuit=circuit, partition_labels=\"AB\", observables=observables\n",
-    ")"
+    ")\n",
+    "subcircuits = partitioned_problem.subcircuits\n",
+    "subobservables = partitioned_problem.subobservables"
    ]
   },
   {

--- a/docs/circuit_cutting/how-tos/how_to_generate_exact_sampling_coefficients.ipynb
+++ b/docs/circuit_cutting/how-tos/how_to_generate_exact_sampling_coefficients.ipynb
@@ -82,9 +82,12 @@
     }
    ],
    "source": [
-    "subcircuits, bases, subobservables = partition_problem(\n",
+    "partitioned_problem = partition_problem(\n",
     "    circuit=circuit, partition_labels=\"AABB\", observables=observables\n",
     ")\n",
+    "subcircuits = partitioned_problem.subcircuits\n",
+    "bases = partitioned_problem.bases\n",
+    "subobservables = partitioned_problem.subobservables\n",
     "subcircuits[\"A\"].draw(\"mpl\", scale=0.6)"
    ]
   },

--- a/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
+++ b/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
@@ -122,7 +122,7 @@
     "\n",
     "- `subcircuits`: a `Dict` mapping partition labels to subcircuits\n",
     "- `subobservables`: a `Dict` mapping partition labels to subobservables\n",
-    "- `bases`: The ``QPDBasis`` instances from each gate decomposition"
+    "- `bases`: a `list` of  ``QPDBasis`` instances, one for each decomposed instruction"
    ]
   },
   {

--- a/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
+++ b/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
@@ -105,9 +105,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subcircuits, bases, subobservables = partition_problem(\n",
+    "partitioned_problem = partition_problem(\n",
     "    circuit=circuit, partition_labels=\"AABB\", observables=observables\n",
-    ")"
+    ")\n",
+    "subcircuits = partitioned_problem.subcircuits\n",
+    "subobservables = partitioned_problem.subobservables\n",
+    "bases = partitioned_problem.bases"
    ]
   },
   {
@@ -115,11 +118,11 @@
    "id": "3518e2df",
    "metadata": {},
    "source": [
-    "`partition_problem` returns:\n",
+    "`partition_problem` returns a data structure that includes:\n",
     "\n",
-    "- `Dict` mapping partition labels to subcircuits\n",
-    "- `Dict` mapping partition labels to subobservables\n",
-    "- The ``QPDBasis`` instances from each gate decomposition"
+    "- `subcircuits`: a `Dict` mapping partition labels to subcircuits\n",
+    "- `subobservables`: a `Dict` mapping partition labels to subobservables\n",
+    "- `bases`: The ``QPDBasis`` instances from each gate decomposition"
    ]
   },
   {

--- a/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
+++ b/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
@@ -214,9 +214,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subcircuits, bases, subobservables = partition_problem(\n",
+    "partitioned_problem = partition_problem(\n",
     "    circuit=qc_1, partition_labels=\"AAAABBBB\", observables=observables_1\n",
-    ")"
+    ")\n",
+    "subcircuits = partitioned_problem.subcircuits\n",
+    "subobservables = partitioned_problem.subobservables\n",
+    "bases = partitioned_problem.bases"
    ]
   },
   {
@@ -224,11 +227,11 @@
    "id": "fd0b0d6c-de39-459c-8b97-6831dab6b3be",
    "metadata": {},
    "source": [
-    "`partition_problem` returns:\n",
+    "`partition_problem` returns a data structure that includes:\n",
     "\n",
-    "- `Dict` mapping partition labels to subcircuits\n",
-    "- `Dict` mapping partition labels to subobservables\n",
-    "- A `list` of  ``QPDBasis`` instances, one for each decomposed instruction"
+    "- `subcircuits`: a `Dict` mapping partition labels to subcircuits\n",
+    "- `subobservables`: a `Dict` mapping partition labels to subobservables\n",
+    "- `bases`: The ``QPDBasis`` instances from each gate decomposition"
    ]
   },
   {

--- a/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
+++ b/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
@@ -231,7 +231,7 @@
     "\n",
     "- `subcircuits`: a `Dict` mapping partition labels to subcircuits\n",
     "- `subobservables`: a `Dict` mapping partition labels to subobservables\n",
-    "- `bases`: The ``QPDBasis`` instances from each gate decomposition"
+    "- `bases`: a `list` of  ``QPDBasis`` instances, one for each decomposed instruction"
    ]
   },
   {


### PR DESCRIPTION
This modifies our use of `partition_problem` in the documentation to avoid unpacking it like a tuple.  We already know that we plan to break the tuple interface in the v0.4 release cycle.  This prepares for the change, by demonstrating code in our documentation that is resilient to our planned changes.  I'm not sure if `PartitionedCuttingProblem` will end up remaining a `namedtuple` or not; if we add a few more elements to it, it might make more sense for it to be a `dataclass`.  Either way, this code should continue to work on v0.4.  I don't want to _hold_ us to this: if there's some other breaking change we need to make, we should do it.  But this change at least provides some hope that our tutorials from v0.3 might work unmodified on v0.4, too.