### PR TITLE
Allow `partition_labels` to be determined automatically in `partition_problem`

### DIFF
--- a/circuit_knitting/cutting/qpd/instructions/qpd_gate.py
+++ b/circuit_knitting/cutting/qpd/instructions/qpd_gate.py
@@ -144,6 +144,12 @@ class TwoQubitQPDGate(BaseQPDGate):
 
         self.definition = qc
 
+    @classmethod
+    def from_instruction(cls, instruction: Instruction, /):
+        """Create a :class:`TwoQubitQPDGate` which represents a cut version of the given ``instruction``."""
+        decomposition = QPDBasis.from_gate(instruction)
+        return TwoQubitQPDGate(decomposition, label=f"cut_{instruction.name}")
+
 
 class SingleQubitQPDGate(BaseQPDGate):
     """

--- a/circuit_knitting/utils/transforms.py
+++ b/circuit_knitting/utils/transforms.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from uuid import uuid4, UUID
 from collections import defaultdict
 from collections.abc import Sequence, Iterable, Hashable, MutableMapping
-from typing import NamedTuple
+from typing import NamedTuple, Callable
 
 from rustworkx import PyGraph, connected_components  # type: ignore[attr-defined]
 from qiskit.circuit import (
@@ -134,12 +134,17 @@ def separate_circuit(
     return SeparatedCircuits(subcircuits, qubit_map)
 
 
-def _partition_labels_from_circuit(circuit: QuantumCircuit) -> list[int]:
+def _partition_labels_from_circuit(
+    circuit: QuantumCircuit,
+    ignore: Callable[[CircuitInstruction], bool] = lambda instr: False,
+) -> list[int]:
     """Generate partition labels from the connectivity of a quantum circuit."""
     # Determine connectivity structure of the circuit
     graph: PyGraph = PyGraph()
     graph.add_nodes_from(range(circuit.num_qubits))
     for instruction in circuit.data:
+        if ignore(instruction):
+            continue
         qubits = instruction.qubits
         for i, q1 in enumerate(qubits):
             for q2 in qubits[i + 1 :]:

--- a/releasenotes/notes/automatic-partition-labels-f90428f66ec5543a.yaml
+++ b/releasenotes/notes/automatic-partition-labels-f90428f66ec5543a.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    :func:`.partition_problem` now works even if ``partition_labels``
+    is not explicitly provided.  In this case, the labels are
+    determined automatically from the connectivity of the input
+    circuit.  For the sake of determining connectivity,
+    :class:`.TwoQubitQPDGate`\ s are ignored, as these instructions
+    are already marked for cutting.  To support this workflow, this
+    release also introduces a new method,
+    :meth:`.TwoQubitQPDGate.from_instruction`, which allows one to
+    create a :class:`.TwoQubitQPDGate` that wraps a given instruction.

--- a/test/cutting/test_cutting_decomposition.py
+++ b/test/cutting/test_cutting_decomposition.py
@@ -240,6 +240,22 @@ class TestCuttingDecomposition(unittest.TestCase):
                 qc, "AABB", observables=PauliList(["IZIZ"])
             )
             assert len(subcircuits) == len(bases) == len(subobservables) == 2
+        with self.subTest("Automatic partition_labels"):
+            qc = QuantumCircuit(4)
+            qc.h(0)
+            qc.cx(0, 2)
+            qc.cx(0, 1)
+            qc.s(3)
+            # Add a TwoQubitQPDGate that, when cut, allows the circuit to
+            # separate
+            qc.append(TwoQubitQPDGate.from_instruction(CXGate()), [1, 3])
+            # Add a TwoQubitQPDGate that, when cut, does *not* allow the
+            # circuit to separate
+            qc.append(TwoQubitQPDGate.from_instruction(CXGate()), [2, 0])
+            subcircuit, *_ = partition_problem(qc)
+            assert subcircuit.keys() == {0, 1}
+            assert subcircuit[0].num_qubits == 3
+            assert subcircuit[1].num_qubits == 1
 
     def test_cut_gates(self):
         with self.subTest("simple circuit"):


### PR DESCRIPTION
... and introduce `TwoQubitQPDGate.from_instruction`.

I've been working on a PR that introduces a how-to for placing single-qubit wire cuts based on #326.  In the course of completing that, I've realized that it would be _very_ nice to have the feature introduced in the current PR, hence its addition to the 0.3 milestone.  Hopefully I can convince you quickly of its value :slightly_smiling_face:.  I'll open the other PR shortly.  It doesn't strictly depend on this, but (as you will see when I do), it becomes much nicer with this.