### PR TITLE
Rename `QPDBasis.from_gate()` to `QPDBasis.from_instruction()`

### DIFF
--- a/circuit_knitting/cutting/__init__.py
+++ b/circuit_knitting/cutting/__init__.py
@@ -60,7 +60,7 @@ Quasi-Probability Decomposition (QPD)
     qpd.generate_qpd_weights
     qpd.generate_qpd_samples
     qpd.decompose_qpd_instructions
-    qpd.qpdbasis_from_gate
+    qpd.qpdbasis_from_instruction
 
 CutQC
 =====

--- a/circuit_knitting/cutting/qpd/__init__.py
+++ b/circuit_knitting/cutting/qpd/__init__.py
@@ -18,6 +18,7 @@ from .qpd import (
     decompose_qpd_instructions,
     WeightType,
     qpdbasis_from_gate,
+    qpdbasis_from_instruction,
 )
 from .instructions import (
     BaseQPDGate,
@@ -28,6 +29,7 @@ from .instructions import (
 
 __all__ = [
     "qpdbasis_from_gate",
+    "qpdbasis_from_instruction",
     "generate_qpd_weights",
     "generate_qpd_samples",
     "decompose_qpd_instructions",

--- a/circuit_knitting/cutting/qpd/instructions/qpd_gate.py
+++ b/circuit_knitting/cutting/qpd/instructions/qpd_gate.py
@@ -147,7 +147,7 @@ class TwoQubitQPDGate(BaseQPDGate):
     @classmethod
     def from_instruction(cls, instruction: Instruction, /):
         """Create a :class:`TwoQubitQPDGate` which represents a cut version of the given ``instruction``."""
-        decomposition = QPDBasis.from_gate(instruction)
+        decomposition = QPDBasis.from_instruction(instruction)
         return TwoQubitQPDGate(decomposition, label=f"cut_{instruction.name}")
 
 

--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -546,19 +546,51 @@ def decompose_qpd_instructions(
     return new_qc
 
 
-_qpdbasis_from_gate_funcs: dict[str, Callable[[Instruction], QPDBasis]] = {}
+_qpdbasis_from_instruction_funcs: dict[str, Callable[[Instruction], QPDBasis]] = {}
 
 
-def _register_qpdbasis_from_gate(*args):
+def _register_qpdbasis_from_instruction(*args):
     def g(f):
         for name in args:
-            _qpdbasis_from_gate_funcs[name] = f
+            _qpdbasis_from_instruction_funcs[name] = f
         return f
 
     return g
 
 
-def qpdbasis_from_gate(gate: Instruction) -> QPDBasis:
+@deprecate_func(
+    since="0.3.0",
+    package_name="circuit-knitting-toolbox",
+    removal_timeline="no earlier than v0.4.0",
+    additional_msg=(
+        "This function has been renamed to "
+        "``circuit_knitting.cutting.qpd.qpdbasis_from_instruction()``."
+    ),
+)
+def qpdbasis_from_gate(gate: Instruction) -> QPDBasis:  # pragma: no cover
+    """
+    Generate a :class:`.QPDBasis` object, given a supported operation.
+
+    All two-qubit gates which implement the :meth:`~qiskit.circuit.Gate.to_matrix` method are
+    supported.  This should include the vast majority of gates with no unbound
+    parameters, but there are some special cases (see, e.g., `qiskit issue #10396
+    <https://github.com/Qiskit/qiskit-terra/issues/10396>`__).
+
+    The :class:`.Move` operation, which can be used to specify a wire cut,
+    is also supported.
+
+    Returns:
+        The newly-instantiated :class:`QPDBasis` object
+
+    Raises:
+        ValueError: Instruction not supported.
+        ValueError: Cannot decompose instruction with unbound parameters.
+        ValueError: ``to_matrix`` conversion of two-qubit gate failed.
+    """
+    return qpdbasis_from_instruction(gate)
+
+
+def qpdbasis_from_instruction(gate: Instruction, /) -> QPDBasis:
     """
     Generate a :class:`.QPDBasis` object, given a supported operation.
 
@@ -579,7 +611,7 @@ def qpdbasis_from_gate(gate: Instruction) -> QPDBasis:
         ValueError: ``to_matrix`` conversion of two-qubit gate failed.
     """
     try:
-        f = _qpdbasis_from_gate_funcs[gate.name]
+        f = _qpdbasis_from_instruction_funcs[gate.name]
     except KeyError:
         pass
     else:
@@ -611,13 +643,13 @@ def _explicitly_supported_instructions() -> set[str]:
     """
     Return a set of instruction names with explicit support for automatic decomposition.
 
-    These instructions are *explicitly* supported by :func:`qpdbasis_from_gate`.
+    These instructions are *explicitly* supported by :func:`qpdbasis_from_instruction`.
     Other instructions may be supported too, via a KAK decomposition.
 
     Returns:
         Set of gate names supported for automatic decomposition.
     """
-    return set(_qpdbasis_from_gate_funcs)
+    return set(_qpdbasis_from_instruction_funcs)
 
 
 def _copy_unique_sublists(lsts: tuple[list, ...], /) -> tuple[list, ...]:
@@ -794,19 +826,19 @@ def _nonlocal_qpd_basis_from_u(
     return QPDBasis(maps, coeffs)
 
 
-@_register_qpdbasis_from_gate("swap")
+@_register_qpdbasis_from_instruction("swap")
 def _(gate: SwapGate):
     return _nonlocal_qpd_basis_from_u([(1 + 1j) / np.sqrt(8)] * 4)
 
 
-@_register_qpdbasis_from_gate("iswap")
+@_register_qpdbasis_from_instruction("iswap")
 def _(gate: iSwapGate):
     return _nonlocal_qpd_basis_from_u([0.5, 0.5j, 0.5j, 0.5])
 
 
-@_register_qpdbasis_from_gate("dcx")
+@_register_qpdbasis_from_instruction("dcx")
 def _(gate: DCXGate):
-    retval = qpdbasis_from_gate(iSwapGate())
+    retval = qpdbasis_from_instruction(iSwapGate())
     # Modify basis according to DCXGate definition in Qiskit circuit library
     # https://github.com/Qiskit/qiskit-terra/blob/e9f8b7c50968501e019d0cb426676ac606eb5a10/qiskit/circuit/library/standard_gates/equivalence_library.py#L938-L944
     for operations in unique_by_id(m[0] for m in retval.maps):
@@ -818,7 +850,7 @@ def _(gate: DCXGate):
     return retval
 
 
-@_register_qpdbasis_from_gate("rxx", "ryy", "rzz", "crx", "cry", "crz")
+@_register_qpdbasis_from_instruction("rxx", "ryy", "rzz", "crx", "cry", "crz")
 def _(gate: RXXGate | RYYGate | RZZGate | CRXGate | CRYGate | CRZGate):
     # Constructing a virtual two-qubit gate by sampling single-qubit operations - Mitarai et al
     # https://iopscience.iop.org/article/10.1088/1367-2630/abd7bc/pdf
@@ -852,7 +884,7 @@ def _(gate: RXXGate | RYYGate | RZZGate | CRXGate | CRYGate | CRZGate):
         ([r_minus], measurement_1),
     ]
 
-    theta = _theta_from_gate(gate)
+    theta = _theta_from_instruction(gate)
 
     if gate.name[0] == "c":
         # Following Eq. (C.4) of https://arxiv.org/abs/2205.00016v2,
@@ -891,37 +923,37 @@ def _(gate: RXXGate | RYYGate | RZZGate | CRXGate | CRYGate | CRZGate):
     return QPDBasis(maps, coeffs)
 
 
-@_register_qpdbasis_from_gate("cs", "csdg")
+@_register_qpdbasis_from_instruction("cs", "csdg")
 def _(gate: CSGate | CSdgGate):
     theta = np.pi / 2
     rot_gate = TGate()
     if gate.name == "csdg":
         theta *= -1
         rot_gate = rot_gate.inverse()
-    retval = qpdbasis_from_gate(CRZGate(theta))
+    retval = qpdbasis_from_instruction(CRZGate(theta))
     for operations in unique_by_id(m[0] for m in retval.maps):
         operations.insert(0, rot_gate)
     return retval
 
 
-@_register_qpdbasis_from_gate("cp")
+@_register_qpdbasis_from_instruction("cp")
 def _(gate: CPhaseGate):
-    theta = _theta_from_gate(gate)
-    retval = qpdbasis_from_gate(CRZGate(theta))
+    theta = _theta_from_instruction(gate)
+    retval = qpdbasis_from_instruction(CRZGate(theta))
     for operations in unique_by_id(m[0] for m in retval.maps):
         operations.insert(0, PhaseGate(theta / 2))
     return retval
 
 
-@_register_qpdbasis_from_gate("csx")
+@_register_qpdbasis_from_instruction("csx")
 def _(gate: CSXGate):
-    retval = qpdbasis_from_gate(CRXGate(np.pi / 2))
+    retval = qpdbasis_from_instruction(CRXGate(np.pi / 2))
     for operations in unique_by_id(m[0] for m in retval.maps):
         operations.insert(0, TGate())
     return retval
 
 
-@_register_qpdbasis_from_gate("cx", "cy", "cz", "ch")
+@_register_qpdbasis_from_instruction("cx", "cy", "cz", "ch")
 def _(gate: CXGate | CYGate | CZGate | CHGate):
     # Constructing a virtual two-qubit gate by sampling single-qubit operations - Mitarai et al
     # https://iopscience.iop.org/article/10.1088/1367-2630/abd7bc/pdf
@@ -959,9 +991,9 @@ def _(gate: CXGate | CYGate | CZGate | CHGate):
     return QPDBasis(maps, coeffs)
 
 
-@_register_qpdbasis_from_gate("ecr")
+@_register_qpdbasis_from_instruction("ecr")
 def _(gate: ECRGate):
-    retval = qpdbasis_from_gate(CXGate())
+    retval = qpdbasis_from_instruction(CXGate())
     # Modify basis according to ECRGate definition in Qiskit circuit library
     # https://github.com/Qiskit/qiskit-terra/blob/d9763523d45a747fd882a7e79cc44c02b5058916/qiskit/circuit/library/standard_gates/equivalence_library.py#L656-L663
     for operations in unique_by_id(m[0] for m in retval.maps):
@@ -972,7 +1004,7 @@ def _(gate: ECRGate):
     return retval
 
 
-def _theta_from_gate(gate: Gate) -> float:
+def _theta_from_instruction(gate: Gate, /) -> float:
     param_gates = {"rxx", "ryy", "rzz", "crx", "cry", "crz", "cp"}
 
     # Internal function should only be called for supported gates
@@ -989,7 +1021,7 @@ def _theta_from_gate(gate: Gate) -> float:
     return theta
 
 
-@_register_qpdbasis_from_gate("move")
+@_register_qpdbasis_from_instruction("move")
 def _(gate: Move):
     i_measurement = [Reset()]
     x_measurement = [HGate(), QPDMeasure(), Reset()]

--- a/circuit_knitting/cutting/qpd/qpd_basis.py
+++ b/circuit_knitting/cutting/qpd/qpd_basis.py
@@ -16,6 +16,7 @@ from collections.abc import Sequence
 
 import numpy as np
 from qiskit.circuit import Instruction
+from qiskit.utils import deprecate_func
 
 
 class QPDBasis:
@@ -114,12 +115,20 @@ class QPDBasis:
         return self._kappa**2
 
     @staticmethod
-    def from_gate(gate: Instruction) -> QPDBasis:
+    @deprecate_func(
+        since="0.3.0",
+        package_name="circuit-knitting-toolbox",
+        removal_timeline="no earlier than v0.4.0",
+        additional_msg=(
+            "This method has been renamed to ``QPDBasis.from_instruction()``."
+        ),
+    )
+    def from_gate(gate: Instruction) -> QPDBasis:  # pragma: no cover
         """
         Generate a :class:`.QPDBasis` object, given a supported operation.
 
         This static method is provided for convenience; it simply
-        calls :func:`~qpd.qpd.qpdbasis_to_gate` under the hood.
+        calls :func:`~qpd.qpd.qpdbasis_from_instruction` under the hood.
 
         Args:
             gate: The instruction from which to instantiate a decomposition
@@ -128,9 +137,28 @@ class QPDBasis:
             The newly-instantiated :class:`QPDBasis` object
         """
         # pylint: disable=cyclic-import
-        from .qpd import qpdbasis_from_gate
+        from .qpd import qpdbasis_from_instruction
 
-        return qpdbasis_from_gate(gate)
+        return qpdbasis_from_instruction(gate)
+
+    @staticmethod
+    def from_instruction(gate: Instruction, /) -> QPDBasis:
+        """
+        Generate a :class:`.QPDBasis` object, given a supported operation.
+
+        This static method is provided for convenience; it simply
+        calls :func:`~qpd.qpd.qpdbasis_from_instruction` under the hood.
+
+        Args:
+            gate: The instruction from which to instantiate a decomposition
+
+        Returns:
+            The newly-instantiated :class:`QPDBasis` object
+        """
+        # pylint: disable=cyclic-import
+        from .qpd import qpdbasis_from_instruction
+
+        return qpdbasis_from_instruction(gate)
 
     def __eq__(self, other):
         """Check equivalence for QPDBasis class."""

--- a/docs/circuit_cutting/how-tos/how_to_generate_exact_sampling_coefficients.ipynb
+++ b/docs/circuit_cutting/how-tos/how_to_generate_exact_sampling_coefficients.ipynb
@@ -251,7 +251,7 @@
     "from circuit_knitting.cutting.qpd import QPDBasis\n",
     "from qiskit.circuit.library.standard_gates import CXGate\n",
     "\n",
-    "qpd_basis_cx = QPDBasis.from_gate(CXGate())\n",
+    "qpd_basis_cx = QPDBasis.from_instruction(CXGate())\n",
     "\n",
     "\n",
     "def _min_nonzero(seq, /):\n",

--- a/releasenotes/notes/qpd_basis_from_instruction-6f46489c395ba20b.yaml
+++ b/releasenotes/notes/qpd_basis_from_instruction-6f46489c395ba20b.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    :meth:`.QPDBasis.from_gate` has been renamed to
+    :meth:`.QPDBasis.from_instruction`.  The original name is
+    deprecated and will be removed no sooner than CKT v0.4.0.

--- a/test/cutting/qpd/test_qpd.py
+++ b/test/cutting/qpd/test_qpd.py
@@ -57,9 +57,9 @@ class TestQPDFunctions(unittest.TestCase):
         # Use HWEA for simplicity and easy visualization
         qpd_circuit = EfficientSU2(4, entanglement="linear", reps=2).decompose()
 
-        # We will instantiate 2 QPDBasis objects using from_gate
+        # We will instantiate 2 QPDBasis objects using from_instruction
         rxx_gate = RXXGate(np.pi / 3)
-        rxx_decomp = QPDBasis.from_gate(rxx_gate)
+        rxx_decomp = QPDBasis.from_instruction(rxx_gate)
 
         # Create two QPDGates and specify each of their bases
         # Labels are only used for visualizations
@@ -144,7 +144,7 @@ class TestQPDFunctions(unittest.TestCase):
         with self.subTest("Single QPD gate"):
             circ = QuantumCircuit(2)
             circ_compare = circ.copy()
-            qpd_basis = QPDBasis.from_gate(RXXGate(np.pi / 3))
+            qpd_basis = QPDBasis.from_instruction(RXXGate(np.pi / 3))
             qpd_gate = TwoQubitQPDGate(qpd_basis)
             circ.data.append(CircuitInstruction(qpd_gate, qubits=[0, 1]))
             decomp_circ = decompose_qpd_instructions(circ, [[0]], map_ids=[0])
@@ -160,7 +160,7 @@ class TestQPDFunctions(unittest.TestCase):
                 == "The number of map IDs (1) must equal the number of decompositions in the circuit (2)."
             )
         with self.subTest("Test unordered indices"):
-            decomp = QPDBasis.from_gate(RXXGate(np.pi / 3))
+            decomp = QPDBasis.from_instruction(RXXGate(np.pi / 3))
             qpd_gate1 = TwoQubitQPDGate(basis=decomp)
             qpd_gate2 = TwoQubitQPDGate(basis=decomp)
 
@@ -193,7 +193,7 @@ class TestQPDFunctions(unittest.TestCase):
                 == "Each decomposition must contain either one or two elements. Found a decomposition with (0) elements."
             )
         with self.subTest("test_mismatching_qpd_ids"):
-            decomp = QPDBasis.from_gate(RXXGate(np.pi / 3))
+            decomp = QPDBasis.from_instruction(RXXGate(np.pi / 3))
             qpd_gate = TwoQubitQPDGate(basis=decomp)
             qc = QuantumCircuit(2)
             qc.h(0)
@@ -216,8 +216,8 @@ class TestQPDFunctions(unittest.TestCase):
                 == "A circuit data index (3) corresponds to a non-QPDGate (h)."
             )
         with self.subTest("test_mismatching_qpd_bases"):
-            decomp1 = QPDBasis.from_gate(RXXGate(np.pi / 3))
-            decomp2 = QPDBasis.from_gate(RXXGate(np.pi / 4))
+            decomp1 = QPDBasis.from_instruction(RXXGate(np.pi / 3))
+            decomp2 = QPDBasis.from_instruction(RXXGate(np.pi / 4))
             qpd_gate1 = SingleQubitQPDGate(basis=decomp1, qubit_id=0)
             qpd_gate2 = SingleQubitQPDGate(basis=decomp2, qubit_id=1)
             qc = QuantumCircuit(2)
@@ -230,7 +230,7 @@ class TestQPDFunctions(unittest.TestCase):
                 == "Gates within the same decomposition must share an equivalent QPDBasis."
             )
         with self.subTest("test_unspecified_qpd_gates"):
-            decomp = QPDBasis.from_gate(RXXGate(np.pi / 3))
+            decomp = QPDBasis.from_instruction(RXXGate(np.pi / 3))
             qpd_gate = TwoQubitQPDGate(basis=decomp)
             qpd_gate1 = SingleQubitQPDGate(basis=decomp, qubit_id=0)
             qpd_gate2 = SingleQubitQPDGate(basis=decomp, qubit_id=1)
@@ -271,7 +271,7 @@ class TestQPDFunctions(unittest.TestCase):
     )
     @unpack
     def test_optimal_kappa_for_known_gates(self, instruction, gamma):
-        assert np.isclose(qpdbasis_from_gate(instruction).kappa, gamma)
+        assert np.isclose(qpdbasis_from_instruction(instruction).kappa, gamma)
 
     @data(
         (RXXGate(np.pi / 7), 5, 5),
@@ -289,7 +289,7 @@ class TestQPDFunctions(unittest.TestCase):
         (CRYGate(np.pi), 5, 5),
     )
     @unpack
-    def test_qpdbasis_from_gate_unique_maps(
+    def test_qpdbasis_from_instruction_unique_maps(
         self, instruction, q0_num_unique, q1_num_unique
     ):
         """
@@ -297,7 +297,7 @@ class TestQPDFunctions(unittest.TestCase):
 
         Make sure it is as expected based on the instruction provided.
         """
-        basis = qpdbasis_from_gate(instruction)
+        basis = qpdbasis_from_instruction(instruction)
         # Consider only maps with non-zero weight
         relevant_maps = [
             m for m, w in zip(basis.maps, basis.coeffs) if not np.isclose(w, 0)
@@ -319,10 +319,10 @@ class TestQPDFunctions(unittest.TestCase):
         ([RXXGate(0.1)] * 16, 10000, 2001),
     )
     @unpack
-    def test_generate_qpd_weights_from_gates(
+    def test_generate_qpd_weights_from_instructions(
         self, gates, num_samples, expected_exact, expected_sampled=None
     ):
-        bases = [QPDBasis.from_gate(gate) for gate in gates]
+        bases = [QPDBasis.from_instruction(gate) for gate in gates]
         samples = generate_qpd_weights(bases, num_samples)
 
         counts = Counter(weight_type for _, weight_type in samples.values())

--- a/test/cutting/qpd/test_qpd_basis.py
+++ b/test/cutting/qpd/test_qpd_basis.py
@@ -93,14 +93,14 @@ class TestQPDBasis(unittest.TestCase):
             -0.24999999999999997,
         ]
 
-    def test_from_gate(self):
+    def test_from_instruction(self):
         rxx_gate = RXXGate(np.pi / 3)
         ryy_gate = RYYGate(np.pi / 5)
         rzz_gate = RZZGate(np.pi / 6)
 
-        rxx_decomp: QPDBasis = QPDBasis.from_gate(rxx_gate)
-        ryy_decomp: QPDBasis = QPDBasis.from_gate(ryy_gate)
-        rzz_decomp: QPDBasis = QPDBasis.from_gate(rzz_gate)
+        rxx_decomp: QPDBasis = QPDBasis.from_instruction(rxx_gate)
+        ryy_decomp: QPDBasis = QPDBasis.from_instruction(ryy_gate)
+        rzz_decomp: QPDBasis = QPDBasis.from_instruction(rzz_gate)
 
         rxx_truth = QPDBasis(self.truth_rxx_maps, self.truth_rxx_coeffs)
         ryy_truth = QPDBasis(self.truth_ryy_maps, self.truth_ryy_coeffs)
@@ -115,12 +115,12 @@ class TestQPDBasis(unittest.TestCase):
         np.testing.assert_allclose(rzz_truth.coeffs, rzz_decomp.coeffs)
 
     def test_eq(self):
-        basis = QPDBasis.from_gate(RXXGate(np.pi / 7))
+        basis = QPDBasis.from_instruction(RXXGate(np.pi / 7))
         self.assertEqual(copy.deepcopy(basis), basis)
 
     def test_unsupported_gate(self):
         with pytest.raises(ValueError) as e_info:
-            QPDBasis.from_gate(C3XGate())
+            QPDBasis.from_instruction(C3XGate())
         assert e_info.value.args[0] == "Instruction not supported: mcx"
 
     def test_unbound_parameter(self):
@@ -128,7 +128,7 @@ class TestQPDBasis(unittest.TestCase):
             # For explicitly support gates, we can give a specific error
             # message due to unbound parameters.
             with pytest.raises(ValueError) as e_info:
-                QPDBasis.from_gate(RZZGate(Parameter("θ")))
+                QPDBasis.from_instruction(RZZGate(Parameter("θ")))
             assert (
                 e_info.value.args[0]
                 == "Cannot decompose (rzz) instruction with unbound parameters."
@@ -138,7 +138,7 @@ class TestQPDBasis(unittest.TestCase):
             # failed, but there are other possible explanations, too.  See
             # https://github.com/Qiskit/qiskit-terra/issues/10396
             with pytest.raises(ValueError) as e_info:
-                QPDBasis.from_gate(XXPlusYYGate(Parameter("θ")))
+                QPDBasis.from_instruction(XXPlusYYGate(Parameter("θ")))
             assert (
                 e_info.value.args[0]
                 == "`to_matrix` conversion of two-qubit gate (xx_plus_yy) failed. Often, this can be caused by unbound parameters."

--- a/test/cutting/test_cutting_decomposition.py
+++ b/test/cutting/test_cutting_decomposition.py
@@ -40,9 +40,9 @@ class TestCuttingDecomposition(unittest.TestCase):
         circuit = EfficientSU2(4, entanglement="linear", reps=2).decompose()
         qpd_circuit = EfficientSU2(4, entanglement="linear", reps=2).decompose()
 
-        # We will instantiate 2 QPDBasis objects using from_gate
+        # We will instantiate 2 QPDBasis objects using from_instruction
         rxx_gate = RXXGate(np.pi / 3)
-        rxx_decomp = QPDBasis.from_gate(rxx_gate)
+        rxx_decomp = QPDBasis.from_instruction(rxx_gate)
 
         # Create two QPDGates and specify each of their bases
         # Labels are only used for visualizations
@@ -232,9 +232,9 @@ class TestCuttingDecomposition(unittest.TestCase):
             qc.rx(np.pi / 4, 1)
             qc.rx(np.pi / 4, 3)
             qc.cx(0, 1)
-            qc.append(TwoQubitQPDGate(QPDBasis.from_gate(Move())), [1, 2])
+            qc.append(TwoQubitQPDGate(QPDBasis.from_instruction(Move())), [1, 2])
             qc.cx(2, 3)
-            qc.append(TwoQubitQPDGate(QPDBasis.from_gate(Move())), [2, 1])
+            qc.append(TwoQubitQPDGate(QPDBasis.from_instruction(Move())), [2, 1])
             qc.cx(0, 1)
             subcircuits, bases, subobservables = partition_problem(
                 qc, "AABB", observables=PauliList(["IZIZ"])
@@ -260,12 +260,7 @@ class TestCuttingDecomposition(unittest.TestCase):
     def test_cut_gates(self):
         with self.subTest("simple circuit"):
             compare_qc = QuantumCircuit(2)
-            compare_qc.append(
-                CircuitInstruction(
-                    TwoQubitQPDGate(QPDBasis.from_gate(CXGate()), label="cut_cx"),
-                    qubits=[0, 1],
-                )
-            )
+            compare_qc.append(TwoQubitQPDGate.from_instruction(CXGate()), [0, 1])
 
             qc = QuantumCircuit(2)
             qc.cx(0, 1)

--- a/test/cutting/test_cutting_workflows.py
+++ b/test/cutting/test_cutting_workflows.py
@@ -36,7 +36,7 @@ def test_transpile_before_realizing_basis_id():
     # SingleQubitQPDGate is allowed.
     backend = FakeLagosV2()
     target = deepcopy(backend.target)
-    sample_qpd_instruction = SingleQubitQPDGate(QPDBasis.from_gate(CXGate()), 1)
+    sample_qpd_instruction = SingleQubitQPDGate(QPDBasis.from_instruction(CXGate()), 1)
     target.add_instruction(
         sample_qpd_instruction,
         {(i,): None for i in range(target.num_qubits)},


### PR DESCRIPTION
This renames `QPDBasis.from_gate()` to `QPDBasis.from_instruction()`.  As of v0.3, the name `from_gate` is no longer appropriate, since the function supports `Move`, which is an `Instruction` but not a `Gate`.  Being that #367 introduced `TwoQubitQPDGate.from_instruction()`, I felt that now is the time to also rename `QPDBasis.from_instruction()` for consistency, so users aren't always confused about which calls it `from_gate` and which calls it `from_instruction`.

I left the argument name as `gate` in some places to reduce the needed size of the diff, but I did mark these places as position-only arguments in the new interface, so that the name can be changed later.

I have also renamed `qpdbasis_from_gate` -> `qpdbasis_from_instruction`, but I left this out of the release note because `qpdbasis_from_gate` was not included in the API refs in v0.2.