### PR TITLE
Fix double-nesting of cutting tutorials & how-tos in table of contents

### DIFF
--- a/docs/circuit_cutting/how-tos/README.rst
+++ b/docs/circuit_cutting/how-tos/README.rst
@@ -1,5 +1,5 @@
-Circuit Cutting How-Tos
--------------------------
+Circuit Cutting How-To Guides
+-----------------------------
 
 - `Generate exact quasi-distributions <how_to_generate_exact_quasi_dists_from_sampler.ipynb>`__:
   Use the :class:`~circuit_knitting.utils.simulation.ExactSampler` interface to generate

--- a/docs/circuit_cutting/how-tos/index.rst
+++ b/docs/circuit_cutting/how-tos/index.rst
@@ -1,6 +1,3 @@
-#############################
-Circuit Cutting How-To Guides
-#############################
 .. include:: README.rst
 
 .. nbgallery::

--- a/docs/circuit_cutting/tutorials/index.rst
+++ b/docs/circuit_cutting/tutorials/index.rst
@@ -1,8 +1,5 @@
 .. _circuit cutting tutorials:
 
-#########################
-Circuit Cutting Tutorials
-#########################
 .. include:: README.rst
 
 .. nbgallery::


### PR DESCRIPTION
I noticed that the cutting tutorials & how-tos are double nested in the [table of contents](https://qiskit-extensions.github.io/circuit-knitting-toolbox/#contents).  This currently happens because each header appears redundantly, in `README.rst` and `index.rst`.  This PR fixes the redundancy by removing headers from `index.rst`.  They are worth keeping in `README.rst`, because there they will be shown to users who browse to those directories on github.com.

I built the docs locally, and they look great with this change.