### PR TITLE
Add a generate_cutting_experiments function

### DIFF
--- a/circuit_knitting/cutting/__init__.py
+++ b/circuit_knitting/cutting/__init__.py
@@ -26,6 +26,7 @@ Circuit Cutting
     partition_circuit_qubits
     partition_problem
     cut_gates
+    generate_cutting_experiments
     decompose_gates
     execute_experiments
     reconstruct_expectation_values
@@ -83,6 +84,7 @@ from .cutting_decomposition import (
     partition_circuit_qubits,
     partition_problem,
     cut_gates,
+    generate_cutting_experiments,
     decompose_gates,
     PartitionedCuttingProblem,
 )
@@ -94,6 +96,7 @@ __all__ = [
     "partition_circuit_qubits",
     "partition_problem",
     "cut_gates",
+    "generate_cutting_experiments",
     "decompose_gates",
     "execute_experiments",
     "reconstruct_expectation_values",

--- a/circuit_knitting/cutting/cutting_decomposition.py
+++ b/circuit_knitting/cutting/cutting_decomposition.py
@@ -481,8 +481,10 @@ def _append_measurement_circuit(
     inplace: bool = False,
 ) -> QuantumCircuit:
     """Append a new classical register and measurement instructions for the given ``CommutingObservableGroup``.
+
     The new register will be named ``"observable_measurements"`` and will be
     the final register in the returned circuit, i.e. ``retval.cregs[-1]``.
+
     Args:
         qc: The quantum circuit
         cog: The commuting observable set for
@@ -493,6 +495,7 @@ def _append_measurement_circuit(
             to have the same number of qubits, and the identity map
             (i.e., ``range(qc.num_qubits)``) is used.
         inplace: Whether to operate on the circuit in place (default: ``False``)
+
     Returns:
         The modified circuit
     """

--- a/circuit_knitting/cutting/cutting_decomposition.py
+++ b/circuit_knitting/cutting/cutting_decomposition.py
@@ -17,18 +17,31 @@ from collections import defaultdict
 from collections.abc import Sequence, Hashable
 from typing import NamedTuple
 
+import numpy as np
 from qiskit.utils import deprecate_func
 from qiskit.circuit import (
     QuantumCircuit,
+    ClassicalRegister,
     CircuitInstruction,
     Barrier,
 )
 from qiskit.quantum_info import PauliList
 
-from ..utils.observable_grouping import observables_restricted_to_subsystem
+from ..utils.iteration import strict_zip
+from ..utils.observable_grouping import (
+    observables_restricted_to_subsystem,
+    ObservableCollection,
+    CommutingObservableGroup,
+)
 from ..utils.transforms import separate_circuit, _partition_labels_from_circuit
-from .qpd.qpd_basis import QPDBasis
-from .qpd.instructions import TwoQubitQPDGate
+from .qpd import (
+    QPDBasis,
+    SingleQubitQPDGate,
+    TwoQubitQPDGate,
+    generate_qpd_weights,
+    decompose_qpd_instructions,
+    WeightType,
+)
 
 
 class PartitionedCuttingProblem(NamedTuple):
@@ -282,3 +295,258 @@ def decompose_observables(
     }
 
     return subobservables_by_subsystem
+
+
+def generate_cutting_experiments(
+    circuits: QuantumCircuit | dict[str | int, QuantumCircuit],
+    observables: PauliList | dict[str | int, PauliList],
+    num_samples: int | float,
+) -> tuple[
+    list[QuantumCircuit] | dict[str | int, list[QuantumCircuit]],
+    list[tuple[float, WeightType]],
+]:
+    """
+    Generate cutting subexperiments and their associated weights.
+
+    If the input circuit and observables are not split into multiple partitions, the output
+    subexperiments will be contained within a 1D array.
+
+    If the input circuit and observables is split into multiple partitions, the output
+    subexperiments will be returned as a dictionary which maps a partition label to to
+    a 1D array containing the subexperiments associated with that partition.
+
+    In both cases, the subexperiment lists are ordered as follows:
+        :math:`[sample_{0}observable_{0}, sample_{0}observable_{1}, ..., sample_{0}observable_{N}, ..., sample_{M}observable_{N}]`
+
+    The weights will always be returned as a 1D array -- one weight for each unique sample.
+
+    Args:
+        circuits: The circuit(s) to partition and separate
+        observables: The observable(s) to evaluate for each unique sample
+        num_samples: The number of samples to draw from the quasi-probability distribution. If set
+            to infinity, the weights will be generated rigorously rather than by sampling from
+            the distribution.
+    Returns:
+        A tuple containing the cutting experiments and their associated weights.
+        If the input circuits is a :class:`QuantumCircuit` instance, the output subexperiments
+        will be a sequence of circuits -- one for every unique sample and observable. If the
+        input circuits are represented as a dictionary keyed by partition labels, the output
+        subexperiments will also be a dictionary keyed by partition labels and containing
+        the subexperiments for each partition.
+        The weights are always a sequence of length-2 tuples, where each tuple contains the
+        weight and the :class:`WeightType`. Each weight corresponds to one unique sample.
+    Raises:
+        ValueError: ``num_samples`` must either be an integer or infinity.
+        ValueError: :class:`SingleQubitQPDGate` instances must have the cut number
+            appended to the gate label.
+        ValueError: :class:`SingleQubitQPDGate` instances are not allowed in unseparated circuits.
+    """
+    if isinstance(num_samples, float):
+        if num_samples != np.inf:
+            raise ValueError("num_samples must either be an integer or infinity.")
+
+    # Retrieving the unique bases, QPD gates, and decomposed observables is slightly different
+    # depending on the format of the execute_experiments input args, but the 2nd half of this function
+    # can be shared between both cases.
+    if isinstance(circuits, QuantumCircuit):
+        is_separated = False
+        subcircuit_list = [circuits]
+        subobservables_by_subsystem = decompose_observables(
+            observables, "A" * len(observables[0])
+        )
+        subsystem_observables = {
+            label: ObservableCollection(subobservables)
+            for label, subobservables in subobservables_by_subsystem.items()
+        }
+        # Gather the unique bases from the circuit
+        bases, qpd_gate_ids = _get_bases(circuits)
+        subcirc_qpd_gate_ids = [qpd_gate_ids]
+
+    else:
+        is_separated = True
+        subcircuit_list = [circuits[key] for key in sorted(circuits.keys())]
+        # Gather the unique bases across the subcircuits
+        subcirc_qpd_gate_ids, subcirc_map_ids = _get_mapping_ids_by_partition(
+            subcircuit_list
+        )
+        bases = _get_bases_by_partition(subcircuit_list, subcirc_qpd_gate_ids)
+
+        # Create the commuting observable groups
+        subsystem_observables = {
+            label: ObservableCollection(so) for label, so in observables.items()
+        }
+
+    # Sample the joint quasiprobability decomposition
+    random_samples = generate_qpd_weights(bases, num_samples=num_samples)
+
+    # Calculate terms in coefficient calculation
+    kappa = np.prod([basis.kappa for basis in bases])
+    num_samples = sum([value[0] for value in random_samples.values()])  # type: ignore
+
+    # Sort samples in descending order of frequency
+    sorted_samples = sorted(random_samples.items(), key=lambda x: x[1][0], reverse=True)
+
+    # Generate the sub-experiments and weights
+    subexperiments_dict: dict[str | int, list[QuantumCircuit]] = defaultdict(list)
+    weights: list[tuple[float, WeightType]] = []
+    for i, (subcircuit, label) in enumerate(
+        strict_zip(subcircuit_list, sorted(subsystem_observables.keys()))
+    ):
+        for z, (map_ids, (redundancy, weight_type)) in enumerate(sorted_samples):
+            actual_coeff = np.prod(
+                [basis.coeffs[map_id] for basis, map_id in strict_zip(bases, map_ids)]
+            )
+            sampled_coeff = (redundancy / num_samples) * (kappa * np.sign(actual_coeff))
+            if i == 0:
+                weights.append((sampled_coeff, weight_type))
+            map_ids_tmp = map_ids
+            if is_separated:
+                map_ids_tmp = tuple(map_ids[j] for j in subcirc_map_ids[i])
+            decomp_qc = decompose_qpd_instructions(
+                subcircuit, subcirc_qpd_gate_ids[i], map_ids_tmp
+            )
+            so = subsystem_observables[label]
+            for j, cog in enumerate(so.groups):
+                meas_qc = _append_measurement_circuit(decomp_qc, cog)
+                subexperiments_dict[label].append(meas_qc)
+
+    subexperiments_out: list[QuantumCircuit] | dict[
+        str | int, list[QuantumCircuit]
+    ] = subexperiments_dict
+    if len(subexperiments_dict.keys()) == 1:
+        subexperiments_out = subexperiments_dict[list(subexperiments_dict.keys())[0]]
+
+    return subexperiments_out, weights
+
+
+def _get_mapping_ids_by_partition(
+    circuits: Sequence[QuantumCircuit],
+) -> tuple[list[list[list[int]]], list[list[int]]]:
+    """Get indices to the QPD gates in each subcircuit and relevant map ids."""
+    # Collect QPDGate id's and relevant map id's for each subcircuit
+    subcirc_qpd_gate_ids: list[list[list[int]]] = []
+    subcirc_map_ids: list[list[int]] = []
+    decomp_ids = set()
+    for circ in circuits:
+        subcirc_qpd_gate_ids.append([])
+        subcirc_map_ids.append([])
+        for i, inst in enumerate(circ.data):
+            if isinstance(inst.operation, SingleQubitQPDGate):
+                try:
+                    decomp_id = int(inst.operation.label.split("_")[-1])
+                except (AttributeError, ValueError):
+                    _raise_bad_qpd_gate_labels()
+                decomp_ids.add(decomp_id)
+                subcirc_qpd_gate_ids[-1].append([i])
+                subcirc_map_ids[-1].append(decomp_id)
+
+    return subcirc_qpd_gate_ids, subcirc_map_ids
+
+
+def _raise_bad_qpd_gate_labels() -> None:
+    raise ValueError(
+        "BaseQPDGate instances in input circuit(s) should have their "
+        'labels suffixed with "_<cut_#>" so that sibling SingleQubitQPDGate '
+        "instances may be grouped and sampled together."
+    )
+
+
+def _get_bases_by_partition(
+    circuits: Sequence[QuantumCircuit], subcirc_qpd_gate_ids: list[list[list[int]]]
+) -> list[QPDBasis]:
+    """Get a list of each unique QPD basis across the subcircuits."""
+    # Collect the bases corresponding to each decomposed operation
+    bases_dict = {}
+    for i, subcirc in enumerate(subcirc_qpd_gate_ids):
+        for basis_id in subcirc:
+            try:
+                decomp_id = int(
+                    circuits[i].data[basis_id[0]].operation.label.split("_")[-1]
+                )
+            except (AttributeError, ValueError):  # pragma: no cover
+                _raise_bad_qpd_gate_labels()  # pragma: no cover
+
+            bases_dict[decomp_id] = circuits[i].data[basis_id[0]].operation.basis
+    bases = [bases_dict[key] for key in sorted(bases_dict.keys())]
+
+    return bases
+
+
+def _append_measurement_circuit(
+    qc: QuantumCircuit,
+    cog: CommutingObservableGroup,
+    /,
+    *,
+    qubit_locations: Sequence[int] | None = None,
+    inplace: bool = False,
+) -> QuantumCircuit:
+    """Append a new classical register and measurement instructions for the given ``CommutingObservableGroup``.
+    The new register will be named ``"observable_measurements"`` and will be
+    the final register in the returned circuit, i.e. ``retval.cregs[-1]``.
+    Args:
+        qc: The quantum circuit
+        cog: The commuting observable set for
+            which to construct measurements
+        qubit_locations: A ``Sequence`` whose length is the number of qubits
+            in the observables, where each element holds that qubit's corresponding
+            index in the circuit.  By default, the circuit and observables are assumed
+            to have the same number of qubits, and the identity map
+            (i.e., ``range(qc.num_qubits)``) is used.
+        inplace: Whether to operate on the circuit in place (default: ``False``)
+    Returns:
+        The modified circuit
+    """
+    if qubit_locations is None:
+        # By default, the identity map.
+        if qc.num_qubits != cog.general_observable.num_qubits:
+            raise ValueError(
+                f"Quantum circuit qubit count ({qc.num_qubits}) does not match qubit "
+                f"count of observable(s) ({cog.general_observable.num_qubits}).  "
+                f"Try providing `qubit_locations` explicitly."
+            )
+        qubit_locations = range(cog.general_observable.num_qubits)
+    else:
+        if (
+            len(qubit_locations) != cog.general_observable.num_qubits
+        ):  # pragma: no cover
+            raise ValueError(  # pragma: no cover
+                f"qubit_locations has {len(qubit_locations)} element(s) but the "
+                f"observable(s) have {cog.general_observable.num_qubits} qubit(s)."
+            )
+    if not inplace:
+        qc = qc.copy()
+
+    # Append the appropriate measurements to qc
+    obs_creg = ClassicalRegister(len(cog.pauli_indices), name="observable_measurements")
+    qc.add_register(obs_creg)
+    # Implement the necessary basis rotations and measurements, as
+    # in BackendEstimator._measurement_circuit().
+    genobs_x = cog.general_observable.x
+    genobs_z = cog.general_observable.z
+    for clbit, subqubit in enumerate(cog.pauli_indices):
+        # subqubit is the index of the qubit in the subsystem.
+        # actual_qubit is its index in the system of interest (if different).
+        actual_qubit = qubit_locations[subqubit]
+        if genobs_x[subqubit]:
+            if genobs_z[subqubit]:
+                qc.sdg(actual_qubit)
+            qc.h(actual_qubit)
+        qc.measure(actual_qubit, obs_creg[clbit])
+
+    return qc
+
+
+def _get_bases(circuit: QuantumCircuit) -> tuple[list[QPDBasis], list[list[int]]]:
+    """Get a list of each unique QPD basis in the circuit and the QPDGate indices."""
+    bases = []
+    qpd_gate_ids = []
+    for i, inst in enumerate(circuit):
+        if isinstance(inst.operation, SingleQubitQPDGate):
+            raise ValueError(
+                "SingleQubitQPDGates are not supported in unseparated circuits."
+            )
+        if isinstance(inst.operation, TwoQubitQPDGate):
+            bases.append(inst.operation.basis)
+            qpd_gate_ids.append([i])
+
+    return bases, qpd_gate_ids

--- a/releasenotes/notes/generate-experiments-554f5ded3bf1a4dc.yaml
+++ b/releasenotes/notes/generate-experiments-554f5ded3bf1a4dc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added a function, :func:`~circuit_knitting.cutting.generate_cutting_experiments`, which generates the cutting subexperiments to be run on the backend - given an input circuit, observable, and number of samples to draw from the input circuit. For each subexperiment, a quasi-distribution will be generated using Qiskit Sampler primitive. :func:`generate_cutting_experiments` also generates the weights associated with each subexperiment. The quasi-distributions and weights are used during expectation value reconstruction.

--- a/test/cutting/test_cutting_decomposition.py
+++ b/test/cutting/test_cutting_decomposition.py
@@ -311,6 +311,36 @@ class TestCuttingDecomposition(unittest.TestCase):
             for exp in subexperiments:
                 assert isinstance(exp, QuantumCircuit)
 
+        with self.subTest("simple circuit and observable as dict"):
+            qc = QuantumCircuit(2)
+            qc.append(
+                SingleQubitQPDGate(
+                    QPDBasis.from_gate(CXGate()), label="cut_cx_0", qubit_id=0
+                ),
+                qargs=[0],
+            )
+            qc.append(
+                SingleQubitQPDGate(
+                    QPDBasis.from_gate(CXGate()), label="cut_cx_0", qubit_id=1
+                ),
+                qargs=[1],
+            )
+            comp_weights = [
+                (0.5, WeightType.EXACT),
+                (0.5, WeightType.EXACT),
+                (0.5, WeightType.EXACT),
+                (-0.5, WeightType.EXACT),
+                (0.5, WeightType.EXACT),
+                (-0.5, WeightType.EXACT),
+            ]
+            subexperiments, weights = generate_cutting_experiments(
+                {"A": qc}, {"A": PauliList(["ZY"])}, np.inf
+            )
+            assert weights == comp_weights
+            assert len(weights) == len(subexperiments)
+            for exp in subexperiments:
+                assert isinstance(exp, QuantumCircuit)
+
         with self.subTest("test bad num_samples"):
             qc = QuantumCircuit(4)
             with pytest.raises(ValueError) as e_info:

--- a/test/cutting/test_cutting_decomposition.py
+++ b/test/cutting/test_cutting_decomposition.py
@@ -25,12 +25,15 @@ from circuit_knitting.cutting import (
     partition_circuit_qubits,
     partition_problem,
     cut_gates,
+    generate_cutting_experiments,
 )
 from circuit_knitting.cutting.instructions import Move
 from circuit_knitting.cutting.qpd import (
     QPDBasis,
+    SingleQubitQPDGate,
     TwoQubitQPDGate,
     BaseQPDGate,
+    WeightType,
 )
 
 
@@ -284,3 +287,75 @@ class TestCuttingDecomposition(unittest.TestCase):
         )
         assert subcircuits.keys() == {"A", "B"}
         assert subobservables.keys() == {"A", "B"}
+
+    def test_generate_cutting_experiments(self):
+        with self.subTest("simple circuit and observable"):
+            qc = QuantumCircuit(2)
+            qc.append(
+                TwoQubitQPDGate(QPDBasis.from_gate(CXGate()), label="cut_cx"),
+                qargs=[0, 1],
+            )
+            comp_weights = [
+                (0.5, WeightType.EXACT),
+                (0.5, WeightType.EXACT),
+                (0.5, WeightType.EXACT),
+                (-0.5, WeightType.EXACT),
+                (0.5, WeightType.EXACT),
+                (-0.5, WeightType.EXACT),
+            ]
+            subexperiments, weights = generate_cutting_experiments(
+                qc, PauliList(["ZZ"]), np.inf
+            )
+            assert weights == comp_weights
+            assert len(weights) == len(subexperiments)
+            for exp in subexperiments:
+                assert isinstance(exp, QuantumCircuit)
+
+        with self.subTest("test bad num_samples"):
+            qc = QuantumCircuit(4)
+            with pytest.raises(ValueError) as e_info:
+                generate_cutting_experiments(qc, PauliList(["ZZZZ"]), 4.5)
+            assert (
+                e_info.value.args[0]
+                == "num_samples must either be an integer or infinity."
+            )
+        with self.subTest("test bad label"):
+            qc = QuantumCircuit(2)
+            qc.append(
+                TwoQubitQPDGate(QPDBasis.from_gate(CXGate()), label="cut_cx"),
+                qargs=[0, 1],
+            )
+            partitioned_problem = partition_problem(
+                qc, "AB", observables=PauliList(["ZZ"])
+            )
+            partitioned_problem.subcircuits["A"].data[0].operation.label = "newlabel"
+            with pytest.raises(ValueError) as e_info:
+                generate_cutting_experiments(
+                    partitioned_problem.subcircuits,
+                    partitioned_problem.subobservables,
+                    np.inf,
+                )
+            assert e_info.value.args[0] == (
+                "BaseQPDGate instances in input circuit(s) should have their labels suffixed with "
+                '"_<cut_#>" so that sibling SingleQubitQPDGate instances may be grouped and sampled together.'
+            )
+        with self.subTest("test bad observable size"):
+            qc = QuantumCircuit(4)
+            with pytest.raises(ValueError) as e_info:
+                generate_cutting_experiments(qc, PauliList(["ZZ"]), np.inf)
+            assert e_info.value.args[0] == (
+                "Quantum circuit qubit count (4) does not match qubit count of observable(s) (2)."
+                "  Try providing `qubit_locations` explicitly."
+            )
+        with self.subTest("test single qubit qpd gate in unseparated circuit"):
+            qc = QuantumCircuit(2)
+            qc.append(
+                SingleQubitQPDGate(QPDBasis.from_gate(CXGate()), 0, label="cut_cx_0"),
+                qargs=[0],
+            )
+            with pytest.raises(ValueError) as e_info:
+                generate_cutting_experiments(qc, PauliList(["ZZ"]), np.inf)
+            assert (
+                e_info.value.args[0]
+                == "SingleQubitQPDGates are not supported in unseparated circuits."
+            )


### PR DESCRIPTION
This should be the first PR to be merged into `main` based on #352 .

This creates a public function `generate_cutting_experiments` which largely mimics the current private function of the same name in `cutting_evaluation`. This function is being moved to `cutting_decomposition`, as subexperiments will be created in that module starting in 0.4.0.


This PR should not be merged prior to 0.3.1, so I am putting it on hold.

The private `_generate_cutting_experiments` will be removed along with the module `cutting_evaluation` in a following PR.