### PR TITLE
qiskit version

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip tox
           python -m pip install toml typer
           python tools/extremal-python-dependencies.py pin-dependencies \
-              "qiskit @ git+https://github.com/Qiskit/qiskit.git" \
+              "qiskit-terra @ git+https://github.com/Qiskit/qiskit.git" \
               "qiskit-nature @ git+https://github.com/qiskit-community/qiskit-nature.git" \
               "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \
               --inplace

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip tox
           python -m pip install toml typer
           python tools/extremal-python-dependencies.py pin-dependencies \
-              "qiskit-terra @ git+https://github.com/Qiskit/qiskit-terra.git" \
+              "qiskit @ git+https://github.com/Qiskit/qiskit.git" \
               "qiskit-nature @ git+https://github.com/qiskit-community/qiskit-nature.git" \
               "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \
               --inplace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = [
     # scipy is currently bounded from above because scipy 1.11 removed the
     # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
     "scipy>=1.5.2,<1.11",
-    "rustworkx>=0.13.0",
+    "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
-    "qiskit>=0.44.0",
+    "qiskit>=0.43.0",
     "qiskit-nature>=0.6.0",
     "qiskit-ibm-runtime>=0.9.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scipy>=1.5.2,<1.11",
     "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
-    "qiskit-terra>=0.24.0",
+    "qiskit>=0.44.0",
     "qiskit-nature>=0.6.0",
     "qiskit-ibm-runtime>=0.9.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     # scipy is currently bounded from above because scipy 1.11 removed the
     # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
     "scipy>=1.5.2,<1.11",
+    "rustworkx>=0.13.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.44.0",
     "qiskit-nature>=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     # scipy is currently bounded from above because scipy 1.11 removed the
     # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
     "scipy>=1.5.2,<1.11",
-    "rustworkx>=0.13.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.44.0",
     "qiskit-nature>=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # scipy is currently bounded from above because scipy 1.11 removed the
     # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
     "scipy>=1.5.2,<1.11",
-    "rustworkx>=0.12.0",
+    "rustworkx>=0.13.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.44.0",
     "qiskit-nature>=0.6.0",


### PR DESCRIPTION
Development version tests are failing because of version confusion between `qiskit` and `qiskit-terra`. This PR resolves this confusion by using only the meta-package `qiskit` in `pyproject.toml`