### PR TITLE
Fix fallout from Qiskit metapackage migration

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -31,8 +31,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip tox
           python -m pip install toml typer
-          python tools/extremal-python-dependencies.py pin-dependencies \
+          python tools/extremal-python-dependencies.py add-dependency \
               "qiskit-terra @ git+https://github.com/Qiskit/qiskit.git" \
+              --inplace
+          python tools/extremal-python-dependencies.py pin-dependencies \
               "qiskit @ git+https://github.com/Qiskit/qiskit.git#subdirectory=qiskit_pkg" \
               "qiskit-nature @ git+https://github.com/qiskit-community/qiskit-nature.git" \
               "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -32,7 +32,8 @@ jobs:
           python -m pip install --upgrade pip tox
           python -m pip install toml typer
           python tools/extremal-python-dependencies.py pin-dependencies \
-              "qiskit @ git+https://github.com/Qiskit/qiskit.git" \
+              "qiskit-terra @ git+https://github.com/Qiskit/qiskit.git" \
+              "qiskit @ git+https://github.com/Qiskit/qiskit.git#subdirectory=qiskit_pkg" \
               "qiskit-nature @ git+https://github.com/qiskit-community/qiskit-nature.git" \
               "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \
               --inplace

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip tox
           python -m pip install toml typer
           python tools/extremal-python-dependencies.py pin-dependencies \
-              "qiskit-terra @ git+https://github.com/Qiskit/qiskit-terra.git" \
+              "qiskit @ git+https://github.com/Qiskit/qiskit.git" \
               "qiskit-nature @ git+https://github.com/qiskit-community/qiskit-nature.git" \
               "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \
               --inplace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = [
     # scipy is currently bounded from above because scipy 1.11 removed the
     # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
     "scipy>=1.5.2,<1.11",
-    "rustworkx>=0.13.0",
+    "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
-    "qiskit>=0.44.0",
+    "qiskit>=0.43.0",
     "qiskit-nature>=0.6.0",
     "qiskit-ibm-runtime>=0.9.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scipy>=1.5.2,<1.11",
     "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
-    "qiskit-terra>=0.24.0",
+    "qiskit>=0.44.0",
     "qiskit-nature>=0.6.0",
     "qiskit-ibm-runtime>=0.9.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.43.0",
-    "qiskit-terra>=0.24.0",
     "qiskit-nature>=0.6.0",
     "qiskit-ibm-runtime>=0.9.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.43.0",
+    "qiskit-terra>=0.24.0",
     "qiskit-nature>=0.6.0",
     "qiskit-ibm-runtime>=0.9.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     # scipy is currently bounded from above because scipy 1.11 removed the
     # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
     "scipy>=1.5.2,<1.11",
+    "rustworkx>=0.13.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.44.0",
     "qiskit-nature>=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     # scipy is currently bounded from above because scipy 1.11 removed the
     # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
     "scipy>=1.5.2,<1.11",
-    "rustworkx>=0.13.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.44.0",
     "qiskit-nature>=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # scipy is currently bounded from above because scipy 1.11 removed the
     # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
     "scipy>=1.5.2,<1.11",
-    "rustworkx>=0.12.0",
+    "rustworkx>=0.13.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.44.0",
     "qiskit-nature>=0.6.0",

--- a/releasenotes/notes/qiskit-metapackage-e755916a18b4c62c.yaml
+++ b/releasenotes/notes/qiskit-metapackage-e755916a18b4c62c.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The ``circuit-knitting-toolbox`` Python package now depends on
+    ``qiskit`` rather than ``qiskit-terra``.  This should have no
+    user-visible effects, but it is something to keep in mind if one
+    sees dependency errors when upgrading CKT.

--- a/tools/extremal-python-dependencies.py
+++ b/tools/extremal-python-dependencies.py
@@ -119,11 +119,7 @@ def _pin_dependencies(mapfunc, inplace: bool):
         "allow-direct-references"
     ] = True
 
-    if inplace:
-        with open("pyproject.toml", "w") as f:
-            toml.dump(d, f)
-    else:
-        print(toml.dumps(d))
+    _save_pyproject_toml(d, inplace)
 
 
 @app.command()
@@ -136,6 +132,23 @@ def pin_dependencies_to_minimum(inplace: bool = False):
 def pin_dependencies(replacements: List[str], inplace: bool = False):
     """Pin dependencies in `pyproject.toml` to the provided versions."""
     _pin_dependencies(mapfunc_replace(replacements), inplace)
+
+
+@app.command()
+def add_dependency(dependency, inplace: bool = False):
+    """Add a dependency for the current project in `pyproject.toml`."""
+    with open("pyproject.toml") as f:
+        d = toml.load(f)
+    d["project"]["dependencies"].append(dependency)
+    _save_pyproject_toml(d, inplace)
+
+
+def _save_pyproject_toml(d: dict, inplace: bool) -> None:
+    if inplace:
+        with open("pyproject.toml", "w") as f:
+            toml.dump(d, f)
+    else:
+        print(toml.dumps(d))
 
 
 if __name__ == "__main__":

--- a/tools/extremal-python-dependencies.py
+++ b/tools/extremal-python-dependencies.py
@@ -135,7 +135,7 @@ def pin_dependencies(replacements: List[str], inplace: bool = False):
 
 
 @app.command()
-def add_dependency(dependency, inplace: bool = False):
+def add_dependency(dependency: str, inplace: bool = False):
     """Add a dependency to `pyproject.toml`."""
     with open("pyproject.toml") as f:
         d = toml.load(f)

--- a/tools/extremal-python-dependencies.py
+++ b/tools/extremal-python-dependencies.py
@@ -136,7 +136,7 @@ def pin_dependencies(replacements: List[str], inplace: bool = False):
 
 @app.command()
 def add_dependency(dependency, inplace: bool = False):
-    """Add a dependency for the current project in `pyproject.toml`."""
+    """Add a dependency to `pyproject.toml`."""
     with open("pyproject.toml") as f:
         d = toml.load(f)
     d["project"]["dependencies"].append(dependency)


### PR DESCRIPTION
This is an alternative to #386, in an attempt to get the "development version tests" to _actually_ use the development version of Qiskit.