### PR TITLE
Add a release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 <div align="left">
 
   [![Stability](https://img.shields.io/badge/Stability-alpha-f4d03f.svg)](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/releases)
+  [![Release](https://img.shields.io/pypi/v/circuit-knitting-toolbox.svg?label=Release)](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/releases)
   ![Platform](https://img.shields.io/badge/%F0%9F%92%BB%20Platform-Linux%20%7C%20macOS%20%7C%20Windows-informational)
-  [![Python](https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-informational?logo=python)](https://www.python.org/)
+  [![Python](https://img.shields.io/pypi/pyversions/circuit-knitting-toolbox?label=Python&logo=python)](https://www.python.org/)
   [![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%200.43.0-6133BD?logo=qiskit)](https://github.com/Qiskit/qiskit)
   [![Qiskit Nature](https://img.shields.io/badge/Qiskit%20Nature-%E2%89%A5%200.6.0-6133BD?logo=qiskit)](https://github.com/Qiskit/qiskit-nature)
 <br />


### PR DESCRIPTION
I just can't stop messing with the badges.

The PR adds a "Release" badge, which shows the latest pypi release version and links to the release page on GitHub.

I've also modified the "Python" badge to get the supported versions automatically from pypi.  This will show the versions supported by the latest _released_ of CKT version, rather than by `main`.  However, I think this is probably what users will actually be the most interested in: what versions are supported if I run `pip install`, right now?

Preview at https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/release-badge/README.md