### PR TITLE
`generate_cutting_experiments` returns coefficients, not weights

### DIFF
--- a/circuit_knitting/cutting/cutting_experiments.py
+++ b/circuit_knitting/cutting/cutting_experiments.py
@@ -42,7 +42,7 @@ def generate_cutting_experiments(
     list[tuple[float, WeightType]],
 ]:
     r"""
-    Generate cutting subexperiments and their associated weights.
+    Generate cutting subexperiments and their associated coefficients.
 
     If the input, ``circuits``, is a :class:`QuantumCircuit` instance, the
     output subexperiments will be contained within a 1D array, and ``observables`` is
@@ -56,7 +56,7 @@ def generate_cutting_experiments(
 
         :math:`[sample_{0}observable_{0}, \ldots, sample_{0}observable_{N}, sample_{1}observable_{0}, \ldots, sample_{M}observable_{N}]`
 
-    The weights will always be returned as a 1D array -- one weight for each unique sample.
+    The coefficients will always be returned as a 1D array -- one coefficient for each unique sample.
 
     Args:
         circuits: The circuit(s) to partition and separate
@@ -65,14 +65,14 @@ def generate_cutting_experiments(
             to infinity, the weights will be generated rigorously rather than by sampling from
             the distribution.
     Returns:
-        A tuple containing the cutting experiments and their associated weights.
+        A tuple containing the cutting experiments and their associated coefficients.
         If the input circuits is a :class:`QuantumCircuit` instance, the output subexperiments
         will be a sequence of circuits -- one for every unique sample and observable. If the
         input circuits are represented as a dictionary keyed by partition labels, the output
         subexperiments will also be a dictionary keyed by partition labels and containing
         the subexperiments for each partition.
-        The weights are always a sequence of length-2 tuples, where each tuple contains the
-        weight and the :class:`WeightType`. Each weight corresponds to one unique sample.
+        The coefficients are always a sequence of length-2 tuples, where each tuple contains the
+        coefficient and the :class:`WeightType`. Each coefficient corresponds to one unique sample.
 
     Raises:
         ValueError: ``num_samples`` must be at least one.
@@ -134,15 +134,15 @@ def generate_cutting_experiments(
     # Sort samples in descending order of frequency
     sorted_samples = sorted(random_samples.items(), key=lambda x: x[1][0], reverse=True)
 
-    # Generate the output experiments and weights
+    # Generate the output experiments and their respective coefficients
     subexperiments_dict: dict[str | int, list[QuantumCircuit]] = defaultdict(list)
-    weights: list[tuple[float, WeightType]] = []
+    coefficients: list[tuple[float, WeightType]] = []
     for z, (map_ids, (redundancy, weight_type)) in enumerate(sorted_samples):
         actual_coeff = np.prod(
             [basis.coeffs[map_id] for basis, map_id in strict_zip(bases, map_ids)]
         )
         sampled_coeff = (redundancy / num_samples) * (kappa * np.sign(actual_coeff))
-        weights.append((sampled_coeff, weight_type))
+        coefficients.append((sampled_coeff, weight_type))
         map_ids_tmp = map_ids
         for i, (subcircuit, label) in enumerate(
             strict_zip(subcircuit_list, sorted(subsystem_observables.keys()))
@@ -166,7 +166,7 @@ def generate_cutting_experiments(
         assert len(subexperiments_out.keys()) == 1
         subexperiments_out = list(subexperiments_dict.values())[0]
 
-    return subexperiments_out, weights
+    return subexperiments_out, coefficients
 
 
 def _get_mapping_ids_by_partition(

--- a/test/cutting/test_cutting_experiments.py
+++ b/test/cutting/test_cutting_experiments.py
@@ -38,7 +38,7 @@ class TestCuttingExperiments(unittest.TestCase):
                 TwoQubitQPDGate(QPDBasis.from_gate(CXGate()), label="cut_cx"),
                 qargs=[0, 1],
             )
-            comp_weights = [
+            comp_coeffs = [
                 (0.5, WeightType.EXACT),
                 (0.5, WeightType.EXACT),
                 (0.5, WeightType.EXACT),
@@ -46,11 +46,11 @@ class TestCuttingExperiments(unittest.TestCase):
                 (0.5, WeightType.EXACT),
                 (-0.5, WeightType.EXACT),
             ]
-            subexperiments, weights = generate_cutting_experiments(
+            subexperiments, coeffs = generate_cutting_experiments(
                 qc, PauliList(["ZZ"]), np.inf
             )
-            assert weights == comp_weights
-            assert len(weights) == len(subexperiments)
+            assert coeffs == comp_coeffs
+            assert len(coeffs) == len(subexperiments)
             for exp in subexperiments:
                 assert isinstance(exp, QuantumCircuit)
 
@@ -68,7 +68,7 @@ class TestCuttingExperiments(unittest.TestCase):
                 ),
                 qargs=[1],
             )
-            comp_weights = [
+            comp_coeffs = [
                 (0.5, WeightType.EXACT),
                 (0.5, WeightType.EXACT),
                 (0.5, WeightType.EXACT),
@@ -76,11 +76,11 @@ class TestCuttingExperiments(unittest.TestCase):
                 (0.5, WeightType.EXACT),
                 (-0.5, WeightType.EXACT),
             ]
-            subexperiments, weights = generate_cutting_experiments(
+            subexperiments, coeffs = generate_cutting_experiments(
                 {"A": qc}, {"A": PauliList(["ZY"])}, np.inf
             )
-            assert weights == comp_weights
-            assert len(weights) == len(subexperiments["A"])
+            assert coeffs == comp_coeffs
+            assert len(coeffs) == len(subexperiments["A"])
             for circ in subexperiments["A"]:
                 assert isinstance(circ, QuantumCircuit)
 


### PR DESCRIPTION
I noticed that `generate_cutting_experiments` really returns _coefficients_, not weights.  While weights (e.g., as returned by `generate_qpd_weights`) are all positive and can be rescaled arbitrarily, coefficients can be either positive or negative and cannot be rescaled arbitrarily.  (Actually, the difference between weights and coefficients deserves some explanation, see #411.)

The misleading jump from "coefficients" to `weights` is in the following snippet:

https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/f33317fde7de9f2c6a5c8916ff301a5388e3eedb/circuit_knitting/cutting/cutting_experiments.py#L144-L145

Interestingly, this was already labeled `coefficients` at the call site in `cutting_experiments.py`.

https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/f33317fde7de9f2c6a5c8916ff301a5388e3eedb/circuit_knitting/cutting/cutting_experiments.py#L144-L145