### PR TITLE
Deprecate `execute_experiments()`

### DIFF
--- a/circuit_knitting/cutting/cutting_decomposition.py
+++ b/circuit_knitting/cutting/cutting_decomposition.py
@@ -143,7 +143,7 @@ def cut_gates(
     """
     if len(circuit.cregs) != 0 or circuit.num_clbits != 0:
         raise ValueError(
-            "Circuits input to execute_experiments should contain no classical registers or bits."
+            "Circuits input to cut_gates should contain no classical registers or bits."
         )
     # Replace specified gates with TwoQubitQPDGates
     if not inplace:
@@ -218,7 +218,7 @@ def partition_problem(
 
     if len(circuit.cregs) != 0 or circuit.num_clbits != 0:
         raise ValueError(
-            "Circuits input to execute_experiments should contain no classical registers or bits."
+            "Circuits input to partition_problem should contain no classical registers or bits."
         )
 
     # Determine partition labels from connectivity (ignoring TwoQubitQPDGates)

--- a/circuit_knitting/cutting/cutting_evaluation.py
+++ b/circuit_knitting/cutting/cutting_evaluation.py
@@ -19,6 +19,7 @@ from collections.abc import Sequence, Hashable
 from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import PauliList
 from qiskit.primitives import BaseSampler, Sampler as TerraSampler, SamplerResult
+from qiskit.utils import deprecate_func
 from qiskit_aer.primitives import Sampler as AerSampler
 
 from .qpd import WeightType
@@ -32,6 +33,16 @@ class CuttingExperimentResults(NamedTuple):
     coeffs: Sequence[tuple[float, WeightType]]
 
 
+@deprecate_func(
+    since="0.4.0",
+    package_name="circuit-knitting-toolbox",
+    removal_timeline="no earlier than v0.5.0",
+    additional_msg=(
+        "Going forward, users should first call ``generate_cutting_experiments()`` "
+        "to generate the subexperiment circuits and then submit these "
+        "circuits directly to the desired Sampler(s)."
+    ),
+)
 def execute_experiments(
     circuits: QuantumCircuit | dict[Hashable, QuantumCircuit],
     subobservables: PauliList | dict[Hashable, PauliList],

--- a/docs/circuit_cutting/how-tos/how_to_generate_exact_quasi_dists_from_sampler.ipynb
+++ b/docs/circuit_cutting/how-tos/how_to_generate_exact_quasi_dists_from_sampler.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "from circuit_knitting.cutting import (\n",
     "    partition_problem,\n",
-    "    execute_experiments,\n",
+    "    generate_cutting_experiments,\n",
     ")"
    ]
   },
@@ -31,7 +31,7 @@
    "id": "940334fd",
    "metadata": {},
    "source": [
-    "Prepare inputs to `execute_experiments`"
+    "Prepare inputs to `generate_cutting_experiments`"
    ]
   },
   {
@@ -54,6 +54,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d6361a9d",
+   "metadata": {},
+   "source": [
+    "Call `generate_cutting_experiments`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d095701f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subexperiments, coefficients = generate_cutting_experiments(\n",
+    "    circuits=subcircuits,\n",
+    "    observables=subobservables,\n",
+    "    num_samples=1000,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "bc59b1be",
    "metadata": {},
    "source": [
@@ -62,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "7a74f709",
    "metadata": {},
    "outputs": [],
@@ -77,27 +99,25 @@
    "id": "8d050fbe",
    "metadata": {},
    "source": [
-    "If `ExactSampler` is used, the quasiprobability distributions returned from `execute_experiments` will be exact and generated from the statevectors of the subexperiments."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "7019d781",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "quasi_dists, coefficients = execute_experiments(\n",
-    "    circuits=subcircuits,\n",
-    "    subobservables=subobservables,\n",
-    "    num_samples=1000,\n",
-    "    samplers=exact_sampler,\n",
-    ")"
+    "If `ExactSampler` is used, the quasiprobability distributions returned from `generate_cutting_experiments` will be exact and generated from the statevectors of the subexperiments."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "7019d781",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = {\n",
+    "    label: exact_sampler.run(subexperiment).result()\n",
+    "    for label, subexperiment in subexperiments.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "7997c631",
    "metadata": {},
    "outputs": [

--- a/docs/circuit_cutting/how-tos/how_to_generate_exact_sampling_coefficients.ipynb
+++ b/docs/circuit_cutting/how-tos/how_to_generate_exact_sampling_coefficients.ipynb
@@ -22,11 +22,10 @@
     "import numpy as np\n",
     "from qiskit.circuit.library import EfficientSU2\n",
     "from qiskit.quantum_info import PauliList\n",
-    "from qiskit_aer.primitives import Sampler\n",
     "\n",
     "from circuit_knitting.cutting import (\n",
     "    partition_problem,\n",
-    "    execute_experiments,\n",
+    "    generate_cutting_experiments,\n",
     ")"
    ]
   },
@@ -114,16 +113,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "7d1f2af8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sampler = Sampler(run_options={\"shots\": 1})"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "fce55187",
    "metadata": {},
@@ -135,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "8c56282f",
    "metadata": {},
    "outputs": [
@@ -180,17 +169,16 @@
        " (0.24999999999999992, <WeightType.EXACT: 1>)]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "quasi_dists, coefficients = execute_experiments(\n",
+    "subexperiments, coefficients = generate_cutting_experiments(\n",
     "    circuits=subcircuits,\n",
-    "    subobservables=subobservables,\n",
+    "    observables=subobservables,\n",
     "    num_samples=np.inf,\n",
-    "    samplers=sampler,\n",
     ")\n",
     "coefficients"
    ]
@@ -209,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "78539fcc",
    "metadata": {},
    "outputs": [
@@ -230,12 +218,12 @@
    "id": "5770cf75",
    "metadata": {},
    "source": [
-    "In this example, we have cut two CNOT gates. Given that the probability of any given mapping in a CNOT decomposition is $1/6$, the probability of any given mapping in the _joint_ distribution combining the two cut CNOT gates is $(1/6)^2$. Therefore, we need to take at least $6^2$ weights in order to retrieve all exact weights from `execute_experiments`."
+    "In this example, we have cut two CNOT gates. Given that the probability of any given mapping in a CNOT decomposition is $1/6$, the probability of any given mapping in the _joint_ distribution combining the two cut CNOT gates is $(1/6)^2$. Therefore, we need to take at least $6^2$ weights in order to retrieve all exact weights from `generate_cutting_experiments`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "f07a6cc3",
    "metadata": {},
    "outputs": [
@@ -271,14 +259,14 @@
    "id": "deb6ad1e",
    "metadata": {},
    "source": [
-    "#### Observe the coefficient weights returned from `execute_experiments` are `WeightType.EXACT`\n",
+    "#### Observe the coefficient weights returned from `generate_cutting_experiments` are `WeightType.EXACT`\n",
     "\n",
     "Above, we determined 36 samples would trigger the coefficients to be returned as exact. Here we set `num_samples` to exactly 36 to test this."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "43d32869",
    "metadata": {},
    "outputs": [
@@ -323,24 +311,23 @@
        " (0.25, <WeightType.EXACT: 1>)]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "quasi_dists, coefficients = execute_experiments(\n",
+    "subexperiments, coefficients = generate_cutting_experiments(\n",
     "    circuits=subcircuits,\n",
-    "    subobservables=subobservables,\n",
+    "    observables=subobservables,\n",
     "    num_samples=36,\n",
-    "    samplers=sampler,\n",
     ")\n",
     "coefficients"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "bbd3742a",
    "metadata": {},
    "outputs": [

--- a/docs/circuit_cutting/how-tos/how_to_specify_cut_wires.ipynb
+++ b/docs/circuit_cutting/how-tos/how_to_specify_cut_wires.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "from circuit_knitting.cutting import (\n",
     "    partition_problem,\n",
-    "    execute_experiments,\n",
+    "    generate_cutting_experiments,\n",
     "    reconstruct_expectation_values,\n",
     ")\n",
     "\n",
@@ -320,23 +320,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "quasi_dists, coefficients = execute_experiments(\n",
+    "subexperiments, coefficients = generate_cutting_experiments(\n",
     "    circuits=subcircuits,\n",
-    "    subobservables=subobservables,\n",
+    "    observables=subobservables,\n",
     "    num_samples=np.inf,\n",
-    "    samplers=Sampler(run_options={\"shots\": 2**12}),\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "dc9fe287",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sampler = Sampler(run_options={\"shots\": 2**12})\n",
+    "results = {\n",
+    "    label: sampler.run(subexperiment).result()\n",
+    "    for label, subexperiment in subexperiments.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "e317a998",
    "metadata": {},
    "outputs": [],
    "source": [
+    "for label in results:\n",
+    "    for i, subexperiment in enumerate(subexperiments[label]):\n",
+    "        results[label].metadata[i][\"num_qpd_bits\"] = len(subexperiment.cregs[0])\n",
     "reconstructed_expvals = reconstruct_expectation_values(\n",
-    "    quasi_dists,\n",
+    "    results,\n",
     "    coefficients,\n",
     "    subobservables,\n",
     ")"
@@ -344,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "5ae568ca",
    "metadata": {},
    "outputs": [

--- a/releasenotes/notes/deprecate-execute_experiments-b96e39653546dcc1.yaml
+++ b/releasenotes/notes/deprecate-execute_experiments-b96e39653546dcc1.yaml
@@ -1,0 +1,9 @@
+---
+deprecations:
+  - |
+    The :func:`.execute_experiments` function has been deprecated.
+    Going forward, users should first call
+    :func:`.generate_cutting_experiments` to generate the
+    subexperiment circuits and then submit these circuits directly to
+    the desired Sampler(s).  The :ref:`tutorials <circuit cutting
+    tutorials>` have been updated with this new workflow.

--- a/test/cutting/test_cutting_decomposition.py
+++ b/test/cutting/test_cutting_decomposition.py
@@ -210,7 +210,7 @@ class TestCuttingDecomposition(unittest.TestCase):
                 partition_problem(circuit, partition_labels, observables=observable)
             assert (
                 e_info.value.args[0]
-                == "Circuits input to execute_experiments should contain no classical registers or bits."
+                == "Circuits input to partition_problem should contain no classical registers or bits."
             )
         with self.subTest("Unsupported phase"):
             # Split 4q HWEA in middle of qubits
@@ -273,7 +273,7 @@ class TestCuttingDecomposition(unittest.TestCase):
                 cut_gates(qc, [0])
             assert (
                 e_info.value.args[0]
-                == "Circuits input to execute_experiments should contain no classical registers or bits."
+                == "Circuits input to cut_gates should contain no classical registers or bits."
             )
 
     def test_unused_qubits(self):

--- a/test/cutting/test_cutting_evaluation.py
+++ b/test/cutting/test_cutting_evaluation.py
@@ -58,6 +58,7 @@ class TestCuttingEvaluation(unittest.TestCase):
         self.observable = PauliList(["ZZ"])
         self.sampler = ExactSampler()
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_execute_experiments(self):
         with self.subTest("Basic test"):
             quasi_dists, coefficients = execute_experiments(
@@ -315,16 +316,3 @@ class TestCuttingEvaluation(unittest.TestCase):
                 e_info.value.args[0]
                 == "Circuits input to execute_experiments should contain no classical registers or bits."
             )
-
-    def test_workflow_with_unused_qubits(self):
-        """Issue #218"""
-        qc = QuantumCircuit(2)
-        subcircuits, _, subobservables = partition_problem(
-            circuit=qc, partition_labels="AB", observables=PauliList(["XX"])
-        )
-        execute_experiments(
-            subcircuits,
-            subobservables,
-            num_samples=1,
-            samplers=AerSampler(),
-        )

--- a/test/cutting/test_cutting_roundtrip.py
+++ b/test/cutting/test_cutting_roundtrip.py
@@ -46,7 +46,7 @@ from qiskit.primitives import Estimator
 from circuit_knitting.utils.simulation import ExactSampler
 from circuit_knitting.cutting import (
     partition_problem,
-    execute_experiments,
+    generate_cutting_experiments,
     reconstruct_expectation_values,
 )
 from circuit_knitting.cutting.instructions import Move
@@ -154,18 +154,25 @@ def test_cutting_exact_reconstruction(example_circuit):
     subcircuits, bases, subobservables = partition_problem(
         qc, "AAB", observables=observables_nophase
     )
-    if np.random.randint(2):
-        samplers = ExactSampler()
-    else:
-        samplers = {label: ExactSampler() for label in subcircuits.keys()}
-    quasi_dists, coefficients = execute_experiments(
-        circuits=subcircuits,
-        subobservables=subobservables,
-        num_samples=np.inf,
-        samplers=samplers,
+    subexperiments, coefficients = generate_cutting_experiments(
+        subcircuits, subobservables, num_samples=np.inf
     )
+    if np.random.randint(2):
+        # Re-use a single sample
+        sampler = ExactSampler()
+        samplers = {label: sampler for label in subcircuits.keys()}
+    else:
+        # One sampler per partition
+        samplers = {label: ExactSampler() for label in subcircuits.keys()}
+    results = {
+        label: sampler.run(subexperiments[label]).result()
+        for label, sampler in samplers.items()
+    }
+    for label in results:
+        for i, subexperiment in enumerate(subexperiments[label]):
+            results[label].metadata[i]["num_qpd_bits"] = len(subexperiment.cregs[0])
     simulated_expvals = reconstruct_expectation_values(
-        quasi_dists, coefficients, subobservables
+        results, coefficients, subobservables
     )
     simulated_expvals *= phases
 

--- a/test/cutting/test_cutting_workflows.py
+++ b/test/cutting/test_cutting_workflows.py
@@ -14,6 +14,7 @@
 import pytest
 from copy import deepcopy
 
+from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import EfficientSU2, CXGate
 from qiskit.quantum_info import PauliList
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
@@ -99,3 +100,16 @@ def test_exotic_labels(label1, label2):
         subobservables,
     )
     assert len(simulated_expvals) == len(observables)
+
+
+def test_workflow_with_unused_qubits():
+    """Issue #218"""
+    qc = QuantumCircuit(2)
+    subcircuits, _, subobservables = partition_problem(
+        circuit=qc, partition_labels="AB", observables=PauliList(["XX"])
+    )
+    generate_cutting_experiments(
+        subcircuits,
+        subobservables,
+        num_samples=10,
+    )


### PR DESCRIPTION
Fixes #405.

The last sentence in this PR's release note will become true as soon as #404 is merged.

Remaining action items
- [x] Modify how-tos to avoid calling `execute_experiments()`.