### PR TITLE
Migrate from `bind_parameters` to `assign_parameters`

### DIFF
--- a/circuit_knitting/forging/entanglement_forging_knitter.py
+++ b/circuit_knitting/forging/entanglement_forging_knitter.py
@@ -199,7 +199,7 @@ class EntanglementForgingKnitter:
                         "ambiguous how to combine the options with the backends."
                     )
         # For now, we only assign the parameters to a copy of the ansatz
-        circuit_u = self._ansatz.circuit_u.bind_parameters(ansatz_parameters)
+        circuit_u = self._ansatz.circuit_u.assign_parameters(ansatz_parameters)
 
         # Create the tensor and superposition stateprep circuits
         # tensor_ansatze   = [U|bi⟩      for |bi⟩       in  tensor_circuits]

--- a/circuit_knitting/utils/simulation.py
+++ b/circuit_knitting/utils/simulation.py
@@ -156,7 +156,7 @@ class ExactSampler(BaseSampler):
     ) -> SamplerResult:
         metadata: list[dict[str, Any]] = [{} for _ in range(len(circuits))]
         bound_circuits = [
-            circuit if len(value) == 0 else circuit.bind_parameters(value)
+            circuit if len(value) == 0 else circuit.assign_parameters(value)
             for circuit, value in strict_zip(circuits, parameter_values)
         ]
         probabilities = [simulate_statevector_outcomes(qc) for qc in bound_circuits]

--- a/docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb
+++ b/docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb
@@ -61,7 +61,7 @@
     "circuit = circuit.decompose()\n",
     "\n",
     "params = [(np.pi * i) / 16 for i in range(len(circuit.parameters))]\n",
-    "circuit = circuit.bind_parameters(params)\n",
+    "circuit.assign_parameters(params, inplace=True)\n",
     "circuit.draw(\"mpl\", fold=-1, scale=0.7)"
    ]
   },

--- a/docs/circuit_cutting/cutqc/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb
+++ b/docs/circuit_cutting/cutqc/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb
@@ -67,7 +67,7 @@
     "circuit = circuit.decompose()\n",
     "\n",
     "params = [(np.pi * i) / 16 for i in range(len(circuit.parameters))]\n",
-    "circuit = circuit.bind_parameters(params)\n",
+    "circuit.assign_parameters(params, inplace=True)\n",
     "circuit.draw(\"mpl\", fold=-1, scale=0.7)"
    ]
   },


### PR DESCRIPTION
This migrates from `bind_parameters` to `assign_parameters`, as `bind_parameters` has been deprecated (https://github.com/Qiskit/qiskit/pull/10792)