### PR TITLE
Enable pylint's `unused-argument` check

### DIFF
--- a/circuit_knitting/cutting/cutqc/wire_cutting.py
+++ b/circuit_knitting/cutting/cutqc/wire_cutting.py
@@ -483,7 +483,6 @@ def find_wire_cuts(
         subcircuits: Sequence[Any] = cut_solution["subcircuits"]
         num_cuts: int = cut_solution["num_cuts"]
         _print_cutter_result(
-            num_subcircuit=len(subcircuits),
             num_cuts=num_cuts,
             subcircuits=subcircuits,
             counter=counter,
@@ -558,7 +557,6 @@ def cut_circuit_wire(
     if verbose:
         print("-" * 20)
         _print_cutter_result(
-            num_subcircuit=len(cut_solution["subcircuits"]),
             num_cuts=cut_solution["num_cuts"],
             subcircuits=cut_solution["subcircuits"],
             counter=cut_solution["counter"],
@@ -569,7 +567,6 @@ def cut_circuit_wire(
 
 
 def _print_cutter_result(
-    num_subcircuit: int,
     num_cuts: int,
     subcircuits: Sequence[QuantumCircuit],
     counter: dict[int, dict[str, int]],
@@ -579,7 +576,6 @@ def _print_cutter_result(
     Pretty print the results.
 
     Args:
-        num_subciruit: The number of subcircuits
         num_cuts: The number of cuts
         subcircuits: The list of subcircuits
         counter: The dictionary containing all meta information regarding
@@ -589,7 +585,8 @@ def _print_cutter_result(
     Returns:
         None
     """
-    for subcircuit_idx in range(num_subcircuit):
+    print(f"num_cuts = {num_cuts}")
+    for subcircuit_idx, subcircuit in enumerate(subcircuits):
         print("subcircuit %d" % subcircuit_idx)
         print(
             "\u03C1 qubits = %d, O qubits = %d, width = %d, effective = %d, depth = %d, size = %d"
@@ -602,7 +599,7 @@ def _print_cutter_result(
                 counter[subcircuit_idx]["size"],
             )
         )
-        print(subcircuits[subcircuit_idx])
+        print(subcircuit)
     print("Estimated cost = %.3e" % classical_cost, flush=True)
 
 

--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -829,17 +829,17 @@ def _nonlocal_qpd_basis_from_u(
 
 
 @_register_qpdbasis_from_instruction("swap")
-def _(gate: SwapGate):
+def _(unused_gate: SwapGate):
     return _nonlocal_qpd_basis_from_u([(1 + 1j) / np.sqrt(8)] * 4)
 
 
 @_register_qpdbasis_from_instruction("iswap")
-def _(gate: iSwapGate):
+def _(unused_gate: iSwapGate):
     return _nonlocal_qpd_basis_from_u([0.5, 0.5j, 0.5j, 0.5])
 
 
 @_register_qpdbasis_from_instruction("dcx")
-def _(gate: DCXGate):
+def _(unused_gate: DCXGate):
     retval = qpdbasis_from_instruction(iSwapGate())
     # Modify basis according to DCXGate definition in Qiskit circuit library
     # https://github.com/Qiskit/qiskit-terra/blob/e9f8b7c50968501e019d0cb426676ac606eb5a10/qiskit/circuit/library/standard_gates/equivalence_library.py#L938-L944
@@ -948,7 +948,7 @@ def _(gate: CPhaseGate):
 
 
 @_register_qpdbasis_from_instruction("csx")
-def _(gate: CSXGate):
+def _(unused_gate: CSXGate):
     retval = qpdbasis_from_instruction(CRXGate(np.pi / 2))
     for operations in unique_by_id(m[0] for m in retval.maps):
         operations.insert(0, TGate())
@@ -956,7 +956,7 @@ def _(gate: CSXGate):
 
 
 @_register_qpdbasis_from_instruction("csxdg")
-def _(gate: ControlledGate):
+def _(unused_gate: ControlledGate):
     retval = qpdbasis_from_instruction(CRXGate(-np.pi / 2))
     for operations in unique_by_id(m[0] for m in retval.maps):
         operations.insert(0, TdgGate())
@@ -1002,7 +1002,7 @@ def _(gate: CXGate | CYGate | CZGate | CHGate):
 
 
 @_register_qpdbasis_from_instruction("ecr")
-def _(gate: ECRGate):
+def _(unused_gate: ECRGate):
     retval = qpdbasis_from_instruction(CXGate())
     # Modify basis according to ECRGate definition in Qiskit circuit library
     # https://github.com/Qiskit/qiskit-terra/blob/d9763523d45a747fd882a7e79cc44c02b5058916/qiskit/circuit/library/standard_gates/equivalence_library.py#L656-L663
@@ -1032,7 +1032,7 @@ def _theta_from_instruction(gate: Gate, /) -> float:
 
 
 @_register_qpdbasis_from_instruction("move")
-def _(gate: Move):
+def _(unused_gate: Move):
     i_measurement = [Reset()]
     x_measurement = [HGate(), QPDMeasure(), Reset()]
     y_measurement = [SdgGate(), HGate(), QPDMeasure(), Reset()]

--- a/circuit_knitting/utils/simulation.py
+++ b/circuit_knitting/utils/simulation.py
@@ -152,7 +152,7 @@ class ExactSampler(BaseSampler):
         self,
         circuits: tuple[QuantumCircuit, ...],
         parameter_values: Sequence[Sequence[float]],
-        **run_options,
+        **ignored_run_options,
     ) -> SamplerResult:
         metadata: list[dict[str, Any]] = [{} for _ in range(len(circuits))]
         bound_circuits = [

--- a/docs/circuit_cutting/cutqc/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb
+++ b/docs/circuit_cutting/cutqc/tutorials/tutorial_3_cutting_with_quantum_serverless.ipynb
@@ -442,7 +442,6 @@
     "    circuit: QuantumCircuit,\n",
     "    subcircuit_instance_probabilities: dict[int, dict[int, np.ndarray]],\n",
     "    cuts: dict[str, Any],\n",
-    "    num_threads: int = 1,\n",
     ") -> np.ndarray:\n",
     "    return reconstruct_full_distribution(\n",
     "        circuit, subcircuit_instance_probabilities, cuts\n",

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,8 @@ commands =
   pydocstyle circuit_knitting/ circuit_knitting_toolbox/
   mypy circuit_knitting/ circuit_knitting_toolbox/
   reno lint
-  pylint -rn --py-version=3.8 --disable=all --enable=reimported,no-self-use,no-else-raise,redefined-argument-from-local,redefined-builtin,raise-missing-from,cyclic-import circuit_knitting/ test/ tools/
-  nbqa pylint -rn --py-version=3.8 --disable=all --enable=reimported,no-self-use,no-else-raise,redefined-argument-from-local,redefined-builtin,raise-missing-from,cyclic-import docs/
+  pylint -rn --py-version=3.8 --disable=all --enable=reimported,no-self-use,no-else-raise,redefined-argument-from-local,redefined-builtin,raise-missing-from,cyclic-import,unused-argument circuit_knitting/ test/ tools/
+  nbqa pylint -rn --py-version=3.8 --disable=all --enable=reimported,no-self-use,no-else-raise,redefined-argument-from-local,redefined-builtin,raise-missing-from,cyclic-import,unused-argument docs/
 
 [testenv:{,py-,py3-,py38-,py39-,py310-,py311-}notebook]
 extras =


### PR DESCRIPTION
Closes #319.

I changed CutQC's `_print_cutter_result` to display `num_cuts` as well (previously, it ignored it).  In passing, I also removed the `num_subcircuit` argument to this function, as it was redundant with `len(subcircuits)`.

In other files, I prefixed intentionally ignored arguments with `unused_` or `ignored_` so pylint will ignore them.