### PR TITLE
Configure mergify to perform stable backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,8 @@
+pull_request_rules:
+  - name: backport
+    conditions:
+      - label=stable backport potential
+    actions:
+      backport:
+        branches:
+          - stable/0.4


### PR DESCRIPTION
This PR configures mergify to perform stable backports for us when we add the "stable backport potential" label to a pull request.  This is essentially the same as [the configuration that qiskit-optimization uses](https://github.com/qiskit-community/qiskit-optimization/blob/main/.mergify.yml), except I removed everything regarding "automerge" and the merge queue.  We seem to get by just fine without a merge queue, and if we _do_ decide to use one, we might as well use GitHub's.

Until now, I've been running `git cherry-pick` manually to backport things to the `stable/*` branches, but using mergify instead will provide mode transparency and opportunities to get involved in the process -- and enforce that tests actually pass before changes are committed to the stable branch.

One potential hiccup: I'm actually not sure if Mergify is enabled in Qiskit-Extensions, so we may need an admin to enable it before it will actually work.