### PR TITLE
Remove upper version bound on scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,7 @@ requires-python = ">=3.8"
 
 dependencies = [
     "numpy>=1.23.0",
-    # scipy is currently bounded from above because scipy 1.11 removed the
-    # `sym_pos` kwarg from `scipy.linalg.solve`, but pyscf has not yet been updated.
-    "scipy>=1.5.2,<1.11",
+    "scipy>=1.5.2",
     "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.43.0",


### PR DESCRIPTION
https://github.com/pyscf/pyscf/issues/1783 has now been resolved in a pyscf release, so we no longer have a restriction on scipy.