### PR TITLE
Use parameterless gates where possible

### DIFF
--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -858,7 +858,7 @@ def _(gate: RXXGate | RYYGate | RZZGate | CRXGate | CRYGate | CRZGate):
     # https://iopscience.iop.org/article/10.1088/1367-2630/abd7bc/pdf
     if gate.name in ("rxx", "crx"):
         pauli = XGate()
-        r_plus = RXGate(0.5 * np.pi)
+        r_plus = SXGate()
         # x basis measurement (and back again)
         measurement_0 = [HGate(), QPDMeasure(), HGate()]
     elif gate.name in ("ryy", "cry"):
@@ -869,7 +869,7 @@ def _(gate: RXXGate | RYYGate | RZZGate | CRXGate | CRYGate | CRZGate):
     else:
         assert gate.name in ("rzz", "crz")
         pauli = ZGate()
-        r_plus = RZGate(0.5 * np.pi)
+        r_plus = SGate()
         # z basis measurement
         measurement_0 = [QPDMeasure()]
 
@@ -901,7 +901,7 @@ def _(gate: RXXGate | RYYGate | RZZGate | CRXGate | CRYGate | CRZGate):
                     operations.append(SdgGate())
                 operations.insert(0, HGate())
                 operations.append(HGate())
-        rot = type(r_plus)(-theta)
+        rot = {"x": RXGate, "y": RYGate, "z": RZGate}[gate.name[2]](-theta)
         for operations in unique_by_id(m[1] for m in maps):
             operations.append(rot)
 

--- a/test/cutting/qpd/test_qpd.py
+++ b/test/cutting/qpd/test_qpd.py
@@ -178,7 +178,7 @@ class TestQPDFunctions(unittest.TestCase):
             creg = ClassicalRegister(1, name="qpd_measurements")
             dx_circ_truth.add_register(creg)
             dx_circ_truth.h(0)
-            dx_circ_truth.rx(np.pi / 2, 1)
+            dx_circ_truth.sx(1)
             dx_circ_truth.measure(0, 0)
             dx_circ_truth.h(0)
             dx_circ = decompose_qpd_instructions(qpd_circ, [[0]], [2])

--- a/test/cutting/qpd/test_qpd_basis.py
+++ b/test/cutting/qpd/test_qpd_basis.py
@@ -26,8 +26,8 @@ class TestQPDBasis(unittest.TestCase):
     def setUp(self):
         # RXX decomp
         x_gate = XGate()
-        x_r_plus = RXGate(1 * np.pi / 2)
-        x_r_minus = RXGate(-1 * np.pi / 2)
+        x_r_plus = SXGate()
+        x_r_minus = SXdgGate()
         x_measure = [HGate(), QPDMeasure(), HGate()]
         self.truth_rxx_maps = [
             ([], []),
@@ -72,8 +72,8 @@ class TestQPDBasis(unittest.TestCase):
 
         # RZZ decomp
         z_gate = ZGate()
-        z_r_plus = RZGate(1 * np.pi / 2)
-        z_r_minus = RZGate(-1 * np.pi / 2)
+        z_r_plus = SGate()
+        z_r_minus = SdgGate()
         z_measure = [QPDMeasure()]
         self.truth_rzz_maps = [
             ([], []),


### PR DESCRIPTION
Now that Qiskit [supports singleton gates](https://github.com/Qiskit/qiskit/pull/10314) for non-controlled, parameterless gates, we might as well use parameterless gates in each place possible to take advantage of this.