### PR TITLE
Don't overcount expanded sum terms in documentation

### DIFF
--- a/circuit_knitting/cutting/cutting_experiments.py
+++ b/circuit_knitting/cutting/cutting_experiments.py
@@ -54,7 +54,7 @@ def generate_cutting_experiments(
 
     In both cases, the subexperiment lists are ordered as follows:
 
-        :math:`[sample_{0}observable_{0}, \ldots, sample_{0}observable_{N}, sample_{1}observable_{0}, \ldots, sample_{M}observable_{N}]`
+        :math:`[sample_{0}observable_{0}, \ldots, sample_{0}observable_{N-1}, sample_{1}observable_{0}, \ldots, sample_{M-1}observable_{N-1}]`
 
     The coefficients will always be returned as a 1D array -- one coefficient for each unique sample.
 

--- a/circuit_knitting/cutting/cutting_reconstruction.py
+++ b/circuit_knitting/cutting/cutting_reconstruction.py
@@ -48,7 +48,7 @@ def reconstruct_expectation_values(
             to generate their experiments should take care to order their subexperiments as follows before submitting them
             to the sampler primitive:
 
-            :math:`[sample_{0}observable_{0}, \ldots, sample_{0}observable_{N}, sample_{1}observable_{0}, \ldots, sample_{M}observable_{N}]`
+            :math:`[sample_{0}observable_{0}, \ldots, sample_{0}observable_{N-1}, sample_{1}observable_{0}, \ldots, sample_{M-1}observable_{N-1}]`
 
         coefficients: A sequence containing the coefficient associated with each unique subexperiment. Each element is a tuple
             containing the coefficient (a ``float``) together with its :class:`.WeightType`, which denotes

--- a/circuit_knitting/forging/cholesky_decomposition.py
+++ b/circuit_knitting/forging/cholesky_decomposition.py
@@ -133,7 +133,7 @@ def convert_cholesky_operator(
     Args:
         operator: A `List[SparsePauliOp]` containing the single-body Hamiltonian followed
             by the Cholesky operators
-            shape: [single-body hamiltonian, cholesky_0, ..., cholesky_N]
+            shape: [single-body hamiltonian, cholesky_0, ..., cholesky_{N-1}]
         ansatz: The ansatz for which to compute expectation values of operator. The
             `EntanglementForgingAnsatz` also contains the bitstrings for each subsystem
 


### PR DESCRIPTION
Since these sums start with 0, they should end with $N-1$; else, there are $N+1$ terms.  Even though we don't explicitly define `N` or `M`, it is most natural for `N` to represent the number of observables or Cholesky operators, rather than have it be one off from that number.