### PR TITLE
Use single gate (`SXGate`) to rotate from Z to Y measurement basis

### DIFF
--- a/circuit_knitting/cutting/cutting_experiments.py
+++ b/circuit_knitting/cutting/cutting_experiments.py
@@ -289,8 +289,11 @@ def _append_measurement_circuit(
         actual_qubit = qubit_locations[subqubit]
         if genobs_x[subqubit]:
             if genobs_z[subqubit]:
-                qc.sdg(actual_qubit)
-            qc.h(actual_qubit)
+                # Rotate Y basis to Z basis
+                qc.sx(actual_qubit)
+            else:
+                # Rotate X basis to Z basis
+                qc.h(actual_qubit)
         qc.measure(actual_qubit, obs_creg[clbit])
 
     return qc

--- a/circuit_knitting/cutting/cutting_experiments.py
+++ b/circuit_knitting/cutting/cutting_experiments.py
@@ -294,6 +294,7 @@ def _append_measurement_circuit(
             else:
                 # Rotate X basis to Z basis
                 qc.h(actual_qubit)
+        # Measure in Z basis
         qc.measure(actual_qubit, obs_creg[clbit])
 
     return qc

--- a/circuit_knitting/cutting/qpd/qpd.py
+++ b/circuit_knitting/cutting/qpd/qpd.py
@@ -731,7 +731,7 @@ def _nonlocal_qpd_basis_from_u(
     #
     # Projective measurements in each basis
     A0x = [HGate(), QPDMeasure(), HGate()]
-    A0y = [SdgGate(), HGate(), QPDMeasure(), HGate(), SGate()]
+    A0y = [SXGate(), QPDMeasure(), SXdgGate()]
     A0z = [QPDMeasure()]
     # Single qubit rotations that swap two axes.  There are "plus" and "minus"
     # versions of these rotations.  The "minus" rotations also flip the sign
@@ -865,7 +865,7 @@ def _(gate: RXXGate | RYYGate | RZZGate | CRXGate | CRYGate | CRZGate):
         pauli = YGate()
         r_plus = RYGate(0.5 * np.pi)
         # y basis measurement (and back again)
-        measurement_0 = [SdgGate(), HGate(), QPDMeasure(), HGate(), SGate()]
+        measurement_0 = [SXGate(), QPDMeasure(), SXdgGate()]
     else:
         assert gate.name in ("rzz", "crz")
         pauli = ZGate()
@@ -1035,15 +1035,15 @@ def _theta_from_instruction(gate: Gate, /) -> float:
 def _(gate: Move):
     i_measurement = [Reset()]
     x_measurement = [HGate(), QPDMeasure(), Reset()]
-    y_measurement = [SdgGate(), HGate(), QPDMeasure(), Reset()]
+    y_measurement = [SXGate(), QPDMeasure(), Reset()]
     z_measurement = [QPDMeasure(), Reset()]
 
     prep_0 = [Reset()]
     prep_1 = [Reset(), XGate()]
     prep_plus = [Reset(), HGate()]
     prep_minus = [Reset(), XGate(), HGate()]
-    prep_iplus = [Reset(), HGate(), SGate()]
-    prep_iminus = [Reset(), XGate(), HGate(), SGate()]
+    prep_iplus = [Reset(), SXdgGate()]
+    prep_iminus = [Reset(), XGate(), SXdgGate()]
 
     # https://arxiv.org/abs/1904.00102v2 Eqs. (12)-(19)
     maps1, maps2, coeffs = zip(

--- a/test/cutting/qpd/test_qpd_basis.py
+++ b/test/cutting/qpd/test_qpd_basis.py
@@ -51,7 +51,7 @@ class TestQPDBasis(unittest.TestCase):
         y_gate = YGate()
         y_r_plus = RYGate(1 * np.pi / 2)
         y_r_minus = RYGate(-1 * np.pi / 2)
-        y_measure = [SdgGate(), HGate(), QPDMeasure(), HGate(), SGate()]
+        y_measure = [SXGate(), QPDMeasure(), SXdgGate()]
         self.truth_ryy_maps = [
             ([], []),
             ([y_gate], [y_gate]),


### PR DESCRIPTION
While reading the OpenQASM 3 paper (page 24 of https://arxiv.org/abs/2104.14722v2), I noticed that there is actually a way to rotate to the Y basis to the Z basis in a single parameterless gate.  We might as well use that (most efficient) method here before it gets repeated many times after we generate many subexperiments.