### PR TITLE
Temporarily pin qiskit-nature < 0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.43.0",
-    "qiskit-nature>=0.6.0",
+    "qiskit-nature>=0.6.0, <0.7",
     "qiskit-ibm-runtime>=0.9.2",
 ]
 

--- a/releasenotes/notes/qiskit-nature-pinned-c359e3933bfef993.yaml
+++ b/releasenotes/notes/qiskit-nature-pinned-c359e3933bfef993.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    ``qiskit-nature`` is now pinned to version 0.6.X, as the
+    entanglement forging code has not yet been updated to work with
+    Qiskit Nature 0.7.0.

--- a/releasenotes/notes/qiskit-nature-pinned-c359e3933bfef993.yaml
+++ b/releasenotes/notes/qiskit-nature-pinned-c359e3933bfef993.yaml
@@ -3,4 +3,6 @@ other:
   - |
     ``qiskit-nature`` is now pinned to version 0.6.X, as the
     entanglement forging code has not yet been updated to work with
-    Qiskit Nature 0.7.0.
+    Qiskit Nature 0.7.0.  Compatibility with Qiskit Nature 0.7.0 is
+    tracked by `issue #406
+    <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/issues/406>`__.


### PR DESCRIPTION
Until #408 is merged (and #406 is thus fixed), we know that CKT will not work with Qiskit Nature 0.7 (a release that is expected some time soon).  We might as well preemptively mark our CKT releases until #408 is merged as being incompatible with Qiskit Nature 0.7.  Otherwise, users might be unpleasantly surprised once Qiskit Nature 0.7 is released and entanglement forging no longer works.

As an alternative, we _could_ just prioritize getting #408 in shape to merge, but there's no harm in having this pinned until that happens.

TODO
- [x] add a release note