### PR TITLE
Migrate from `qiskit.algorithms` to `qiskit-algorithms` package

### DIFF
--- a/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
+++ b/circuit_knitting/forging/entanglement_forging_ground_state_solver.py
@@ -25,7 +25,7 @@ from typing import (
 import scipy
 import numpy as np
 
-from qiskit.algorithms.optimizers import SPSA, Optimizer, OptimizerResult
+from qiskit_algorithms.optimizers import SPSA, Optimizer, OptimizerResult
 from qiskit_nature.second_q.problems import (
     ElectronicStructureProblem,
     EigenstateResult,

--- a/docs/entanglement_forging/tutorials/tutorial_1_getting_started.ipynb
+++ b/docs/entanglement_forging/tutorials/tutorial_1_getting_started.ipynb
@@ -144,10 +144,10 @@
    "metadata": {},
    "source": [
     "### Set up `EntanglementForgingGroundStateSolver`\n",
-    "Next, we set up the `EntanglementForgingGroundStateSolver`. It is passed the ansatz, a classical optimizer ([COBYLA](https://qiskit.org/documentation/stubs/qiskit.algorithms.optimizers.COBYLA.html?highlight=cobyla#qiskit.algorithms.optimizers.COBYLA), in this case), and an initial point.\n",
+    "Next, we set up the `EntanglementForgingGroundStateSolver`. It is passed the ansatz, a classical optimizer ([COBYLA](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.optimizers.COBYLA.html), in this case), and an initial point.\n",
     "\n",
     " * The `ansatz` field is required.\n",
-    " * If no optimizer is passed, [SPSA](https://qiskit.org/documentation/stubs/qiskit.algorithms.optimizers.SPSA.html) with default settings will be used.\n",
+    " * If no optimizer is passed, [SPSA](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.optimizers.SPSA.html) with default settings will be used.\n",
     " * If a Qiskit Runtime Service is not passed, then a local simulator will be used with the [Qiskit Primitives](https://qiskit.org/documentation/apidoc/primitives.html), and the `backend_names` argument will be ignored.\n",
     " * If multiple backend names are passed, the expectation value calculations at each iteration will be divided evenly among them and calculated in parallel.\n",
     " * If a single options argument is passed, it will be used for all backends. If a list of options is passed, they will be synchronized with the backends 1:1\n",
@@ -163,7 +163,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from qiskit.algorithms.optimizers import COBYLA\n",
+    "from qiskit_algorithms.optimizers import COBYLA\n",
     "from circuit_knitting.forging import (\n",
     "    EntanglementForgingGroundStateSolver,\n",
     ")\n",

--- a/docs/entanglement_forging/tutorials/tutorial_2_forging_with_quantum_serverless.ipynb
+++ b/docs/entanglement_forging/tutorials/tutorial_2_forging_with_quantum_serverless.ipynb
@@ -230,7 +230,7 @@
    "outputs": [],
    "source": [
     "from typing import Sequence\n",
-    "from qiskit.algorithms.optimizers import Optimizer\n",
+    "from qiskit_algorithms.optimizers import Optimizer\n",
     "from qiskit.result import Result\n",
     "from quantum_serverless import distribute_task\n",
     "from circuit_knitting.forging import (\n",
@@ -315,7 +315,7 @@
     "%%capture\n",
     "\n",
     "from dataclasses import asdict\n",
-    "from qiskit.algorithms.optimizers import COBYLA\n",
+    "from qiskit_algorithms.optimizers import COBYLA\n",
     "from quantum_serverless import get\n",
     "\n",
     "optimizer = COBYLA()\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "rustworkx>=0.12.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.43.0",
+    "qiskit-algorithms>=0.2.1",
     "qiskit-nature>=0.6.0, <0.7",
     "qiskit-ibm-runtime>=0.9.2",
 ]

--- a/releasenotes/notes/qiskit-algorithms-ec3fe782619bab45.yaml
+++ b/releasenotes/notes/qiskit-algorithms-ec3fe782619bab45.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    CKT now depends on the `qiskit-algorithms
+    <https://github.com/qiskit-community/qiskit-algorithms>`__
+    package.  This new package replaces the ``qiskit.algorithms``
+    module, which was deprecated in Qiskit 0.44.

--- a/test/forging/test_entanglement_forging_ground_state_solver.py
+++ b/test/forging/test_entanglement_forging_ground_state_solver.py
@@ -17,10 +17,9 @@ import importlib.util
 
 import pytest
 import numpy as np
-from qiskit.algorithms.optimizers import SPSA
+from qiskit_algorithms.optimizers import SPSA, COBYLA
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.circuit.library import TwoLocal
-from qiskit.algorithms.optimizers import COBYLA
 from qiskit_nature.units import DistanceUnit
 from qiskit_nature.second_q.drivers import PySCFDriver
 from qiskit_nature.second_q.problems import (


### PR DESCRIPTION
The `qiskit.algorithms` module was deprecated in Qiskit Terra 0.25, which was released on July 27.  This updates the code to use the `qiskit-algorithms` package instead, to ensure compatibility with future Qiskit versions.