### PR TITLE
Clean up roundtrip tests

### DIFF
--- a/test/cutting/test_cutting_roundtrip.py
+++ b/test/cutting/test_cutting_roundtrip.py
@@ -132,17 +132,8 @@ def example_circuit(
 
 
 def test_cutting_exact_reconstruction(example_circuit):
-    """Test gate-cut circuit vs original circuit on statevector simulator
-
-    This test uses a statevector simulator to consider the expectation value of
-    each of the :math:`2^N` different possible projection operators in the z
-    basis at the end of the circuit (or in other words, the precise probability
-    of each full-circuit measurement outcome in the limit of infinite shots).
-    This test ensures that each such expectation value remains the same under
-    the given QPD decomposed gates.
-    """
-    qc0 = example_circuit
-    qc = qc0.copy()
+    """Test gate-cut circuit vs original circuit on statevector simulator"""
+    qc = example_circuit
 
     observables = PauliList(["III", "IIY", "XII", "XYZ", "iZZZ", "-XZI"])
     phases = np.array([(-1j) ** obs.phase for obs in observables])
@@ -150,7 +141,7 @@ def test_cutting_exact_reconstruction(example_circuit):
 
     estimator = Estimator()
     exact_expvals = (
-        estimator.run([qc0] * len(observables), list(observables)).result().values
+        estimator.run([qc] * len(observables), list(observables)).result().values
     )
     subcircuits, bases, subobservables = partition_problem(
         qc, "AAB", observables=observables_nophase
@@ -159,7 +150,7 @@ def test_cutting_exact_reconstruction(example_circuit):
         subcircuits, subobservables, num_samples=np.inf
     )
     if np.random.randint(2):
-        # Re-use a single sample
+        # Re-use a single sampler
         sampler = ExactSampler()
         samplers = {label: sampler for label in subcircuits.keys()}
     else:
@@ -172,14 +163,14 @@ def test_cutting_exact_reconstruction(example_circuit):
     for label in results:
         for i, subexperiment in enumerate(subexperiments[label]):
             results[label].metadata[i]["num_qpd_bits"] = len(subexperiment.cregs[0])
-    simulated_expvals = reconstruct_expectation_values(
+    reconstructed_expvals = reconstruct_expectation_values(
         results, coefficients, subobservables
     )
-    simulated_expvals *= phases
+    reconstructed_expvals *= phases
 
-    logger.info("Max error: %f", np.max(np.abs(exact_expvals - simulated_expvals)))
+    logger.info("Max error: %f", np.max(np.abs(exact_expvals - reconstructed_expvals)))
 
-    assert np.allclose(exact_expvals, simulated_expvals, atol=1e-8)
+    assert np.allclose(exact_expvals, reconstructed_expvals, atol=1e-8)
 
 
 def test_sampler_with_identity_subobservable(example_circuit):

--- a/test/cutting/test_cutting_workflows.py
+++ b/test/cutting/test_cutting_workflows.py
@@ -94,12 +94,12 @@ def test_exotic_labels(label1, label2):
         for i, subexperiment in enumerate(subexperiments[label]):
             results[label].metadata[i]["num_qpd_bits"] = len(subexperiment.cregs[0])
 
-    simulated_expvals = reconstruct_expectation_values(
+    reconstructed_expvals = reconstruct_expectation_values(
         results,
         coefficients,
         subobservables,
     )
-    assert len(simulated_expvals) == len(observables)
+    assert len(reconstructed_expvals) == len(observables)
 
 
 def test_workflow_with_unused_qubits():


### PR DESCRIPTION
- remove an outdated docstring comment
- `simuated_expvals` -> `reconstructed_expvals` for consistency with tutorials
- remove unnecessary circuit copy
- fix typo