### PR TITLE
Update forging how-to to Qiskit Nature 0.5

### DIFF
--- a/docs/entanglement_forging/how-tos/specify-problem.rst
+++ b/docs/entanglement_forging/how-tos/specify-problem.rst
@@ -2,30 +2,31 @@
 How to specify the problem
 ##########################
 
-To specify the problem, we follow the Qiskit Nature workflow. We set up the ``molecule`` object, specify the driver, and instantiate the ``ElectronicStructureProblem``.
+To specify the problem, we follow the Qiskit Nature workflow. We set up the ``molecule`` object, specify the driver, and instantiate the :class:`.ElectronicStructureProblem`.
 
 We first require the following modules:
 
 .. jupyter-execute::
 
-   from qiskit_nature.drivers import Molecule
-   from qiskit_nature.drivers.second_quantization import PySCFDriver
-   from qiskit_nature.problems.second_quantization import ElectronicStructureProblem
+   from qiskit_nature.second_q.formats import MoleculeInfo
+   from qiskit_nature.second_q.drivers import PySCFDriver
+   from qiskit_nature.second_q.problems import ElectronicBasis
 
 To set up the ``molecule`` object, we specify the individual atoms and their positions:
 
 .. jupyter-execute::
 
-   molecule = Molecule(
-       geometry=[
-           ("H", [0.0, 0.0, 0.0]),
-           ("H", [0.0, 0.0, 0.735]),
+   molecule = MoleculeInfo(
+       ["H", "H"],
+       [
+           (0.0, 0.0, 0.0),
+           (0.0, 0.0, 0.735),
        ],
        charge=0,
        multiplicity=1, # Multiplicity (2S+1) of the molecule, where S is the total spin angular momentum
    )
 
-We then specify the driver (see ``PySCFDriver``) and load the molecule into the driver:
+We then specify the driver (see :class:`.PySCFDriver`) and load the molecule into the driver:
 
 .. jupyter-execute::
 
@@ -33,8 +34,10 @@ We then specify the driver (see ``PySCFDriver``) and load the molecule into the 
 
 Here, the driver is an algorithm class that knows how to calculate the second quantized operators.
 
-Finally, we instantiate the ``ElectronicStructureProblem``, a class which wraps a number of different types of drivers:
+Finally, we instantiate the :class:`.ElectronicStructureProblem`, a class which wraps a number of different types of drivers:
 
 .. jupyter-execute::
+   :stderr:
 
-   problem = ElectronicStructureProblem(driver)
+   driver.run()
+   problem = driver.to_problem(basis=ElectronicBasis.AO)


### PR DESCRIPTION
This was overlooked in #83.  It is now causing CI errors in the docs workflow (see #448), now that a Qiskit version without `PauliTable` has been released.