### PR TITLE
Remove qiskit `main` from "developments versions" CI workflow

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -31,11 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip tox
           python -m pip install toml typer
-          python tools/extremal-python-dependencies.py add-dependency \
-              "qiskit-terra @ git+https://github.com/Qiskit/qiskit.git" \
-              --inplace
           python tools/extremal-python-dependencies.py pin-dependencies \
-              "qiskit @ git+https://github.com/Qiskit/qiskit.git#subdirectory=qiskit_pkg" \
               "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \
               --inplace
       - name: Modify tox.ini for more thorough check


### PR DESCRIPTION
Following https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/issues/406#issuecomment-1807252032