### PR TITLE
Pin `aiohttp != 3.9.0` during notebook tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ docs = [
 notebook-dependencies = [
     "circuit-knitting-toolbox[cplex,pyscf]",
     "quantum-serverless>=0.0.7",
+    "aiohttp!=3.9.0",
     "matplotlib",
     "ipywidgets",
     "pylatexenc",


### PR DESCRIPTION
This fixes the notebook tests (and CI).  See discussion at #453.