### PR TITLE
Install `async-timeout` rather than pin `aiohttp`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ docs = [
 notebook-dependencies = [
     "circuit-knitting-toolbox[cplex,pyscf]",
     "quantum-serverless>=0.0.7",
-    "aiohttp!=3.9.0",
+    "async-timeout",
     "matplotlib",
     "ipywidgets",
     "pylatexenc",


### PR DESCRIPTION
In #454, I pinned `aiohttp`, but the failure was actually due to `async-timeout` not being installed
(https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/issues/453#issuecomment-1819548746).

This PR updates `pyproject.toml` in accordance with this root cause.

We can remove this line once a version of ray is released that fixes https://github.com/ray-project/ray/issues/41267.