### PR TITLE
Remove `async-timeout` from notebook dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ docs = [
 notebook-dependencies = [
     "circuit-knitting-toolbox[cplex,pyscf]",
     "quantum-serverless>=0.0.7",
-    "async-timeout",
     "matplotlib",
     "ipywidgets",
     "pylatexenc",


### PR DESCRIPTION
This will need to wait until Ray 2.9.0 is released, following https://github.com/ray-project/ray/issues/41267#issuecomment-1819909717.

Fixes #453.