### PR TITLE
Remove unnecessary resets in `generate_cutting_experiments`

### DIFF
--- a/circuit_knitting/cutting/cutting_experiments.py
+++ b/circuit_knitting/cutting/cutting_experiments.py
@@ -90,7 +90,6 @@ def generate_cutting_experiments(
             appended to the gate label so they may be associated with other gates belonging
             to the same cut.
         ValueError: :class:`SingleQubitQPDGate` instances are not allowed in unseparated circuits.
-
     """
     if isinstance(circuits, QuantumCircuit) and not isinstance(observables, PauliList):
         raise ValueError(

--- a/circuit_knitting/utils/__init__.py
+++ b/circuit_knitting/utils/__init__.py
@@ -59,6 +59,12 @@ Transforms (:mod:`circuit_knitting.utils.transforms`)
 =============================================================
 
 .. automodule:: circuit_knitting.utils.transforms
+
+===================================================================
+Transpiler passes (:mod:`circuit_knitting.utils.transpiler_passes`)
+===================================================================
+
+.. automodule:: circuit_knitting.utils.transpiler_passes
 """
 
 from .orbital_reduction import reduce_bitstrings

--- a/circuit_knitting/utils/transpiler_passes.py
+++ b/circuit_knitting/utils/transpiler_passes.py
@@ -1,0 +1,66 @@
+# This code is a Qiskit project.
+
+# (C) Copyright IBM 2023.
+
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Transpiler passes useful for circuit knitting.
+
+.. currentmodule:: circuit_knitting.utils.transpiler_passes
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   RemoveFinalReset
+   ConsolidateResets
+"""
+
+from qiskit.circuit import Reset, Qubit
+from qiskit.dagcircuit import DAGOpNode
+from qiskit.transpiler.basepasses import TransformationPass
+
+
+class RemoveFinalReset(TransformationPass):
+    """Remove reset when it is the final instruction on a qubit wire."""
+
+    def run(self, dag):
+        """Run the RemoveFinalReset pass on ``dag``.
+
+        Args:
+            dag (DAGCircuit): the DAG to be optimized.
+
+        Returns:
+            DAGCircuit: the optimized DAG.
+        """
+        for output_node in dag.output_map.values():
+            if isinstance(output_node.wire, Qubit):
+                pred = next(dag.predecessors(output_node))
+                if isinstance(pred, DAGOpNode) and isinstance(pred.op, Reset):
+                    dag.remove_op_node(pred)
+        return dag
+
+
+class ConsolidateResets(TransformationPass):
+    """Consolidate a run duplicate resets in to a single reset."""
+
+    def run(self, dag):
+        """Run the ConsolidateResets pass on ``dag``.
+
+        Args:
+            dag (DAGCircuit): the DAG to be optimized.
+
+        Returns:
+            DAGCircuit: the optimized DAG.
+        """
+        resets = dag.op_nodes(Reset)
+        for reset in resets:
+            successor = next(dag.successors(reset))
+            if isinstance(successor, DAGOpNode) and isinstance(successor.op, Reset):
+                dag.remove_op_node(reset)
+        return dag

--- a/releasenotes/notes/remove-redundant-resets-1893a61a341e6ce8.yaml
+++ b/releasenotes/notes/remove-redundant-resets-1893a61a341e6ce8.yaml
@@ -1,0 +1,12 @@
+---
+upgrade:
+  - |
+    The :func:`.generate_cutting_experiments` function now performs
+    some optimizations on the generated circuits before returning them
+    to the user.  In particular, it performs the
+    :class:`~qiskit.transpiler.passes.RemoveResetInZeroState`,
+    :class:`.RemoveFinalReset`, and :class:`.ConsolidateResets`
+    passes, so that circuits with cut wires and no re-used qubits are
+    transformed into subexperiments that contain no
+    :class:`~qiskit.circuit.library.Reset`\ s.  This allows such circuits to
+    work on a greater variety of hardware backends.

--- a/test/utils/test_transpiler_passes.py
+++ b/test/utils/test_transpiler_passes.py
@@ -1,0 +1,132 @@
+# This code is a Qiskit project.
+
+# (C) Copyright IBM 2023.
+
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for CKT transpilation passes."""
+
+import unittest
+
+from qiskit import QuantumRegister, QuantumCircuit
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passes import DAGFixedPoint
+from qiskit.converters import circuit_to_dag
+
+from circuit_knitting.utils.transpiler_passes import RemoveFinalReset, ConsolidateResets
+
+
+class TestRemoveFinalReset(unittest.TestCase):
+    """Test remove-reset-in-zero-state optimizations."""
+
+    def test_optimize_single_reset(self):
+        """Remove a single final reset
+        qr0:--[H]--|0>--   ==>    qr0:--[H]--
+        """
+        qr = QuantumRegister(1, "qr")
+        circuit = QuantumCircuit(qr)
+        circuit.h(0)
+        circuit.reset(qr)
+        dag = circuit_to_dag(circuit)
+
+        expected = QuantumCircuit(qr)
+        expected.h(0)
+
+        pass_ = RemoveFinalReset()
+        after = pass_.run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
+    def test_dont_optimize_non_final_reset(self):
+        """Do not remove reset if not final instruction
+        qr0:--|0>--[H]--   ==>    qr0:--|0>--[H]--
+        """
+        qr = QuantumRegister(1, "qr")
+        circuit = QuantumCircuit(qr)
+        circuit.reset(qr)
+        circuit.h(qr)
+        dag = circuit_to_dag(circuit)
+
+        expected = QuantumCircuit(qr)
+        expected.reset(qr)
+        expected.h(qr)
+
+        pass_ = RemoveFinalReset()
+        after = pass_.run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
+    def test_optimize_single_reset_in_diff_qubits(self):
+        """Remove a single final reset in different qubits
+        qr0:--[H]--|0>--          qr0:--[H]--
+                      ==>
+        qr1:--[X]--|0>--          qr1:--[X]----
+        """
+        qr = QuantumRegister(2, "qr")
+        circuit = QuantumCircuit(qr)
+        circuit.h(0)
+        circuit.x(1)
+        circuit.reset(qr)
+        dag = circuit_to_dag(circuit)
+
+        expected = QuantumCircuit(qr)
+        expected.h(0)
+        expected.x(1)
+
+        pass_ = RemoveFinalReset()
+        after = pass_.run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
+
+class TestRemoveFinalResetFixedPoint(unittest.TestCase):
+    """Test RemoveFinalReset in a transpiler, using fixed point."""
+
+    def test_two_resets(self):
+        """Remove two final resets
+        qr0:--[H]-|0>-|0>--   ==>    qr0:--[H]--
+        """
+        qr = QuantumRegister(1, "qr")
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.reset(qr[0])
+        circuit.reset(qr[0])
+
+        expected = QuantumCircuit(qr)
+        expected.h(qr[0])
+
+        pass_manager = PassManager()
+        pass_manager.append(
+            [RemoveFinalReset(), DAGFixedPoint()],
+            do_while=lambda property_set: not property_set["dag_fixed_point"],
+        )
+        after = pass_manager.run(circuit)
+
+        self.assertEqual(expected, after)
+
+
+class TestConsolidateResets(unittest.TestCase):
+    """Test consolidate-resets optimization."""
+
+    def test_consolidate_double_reset(self):
+        """Consolidate a pair of resets.
+        qr0:--|0>--|0>--   ==>    qr0:--|0>--
+        """
+        qr = QuantumRegister(1, "qr")
+        circuit = QuantumCircuit(qr)
+        circuit.reset(qr)
+        circuit.reset(qr)
+        dag = circuit_to_dag(circuit)
+
+        expected = QuantumCircuit(qr)
+        expected.reset(qr)
+
+        pass_ = ConsolidateResets()
+        after = pass_.run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)


### PR DESCRIPTION
Fixes #452.

I'd still like to swap the tutorial and how-to as suggested in the second point at https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/issues/452#issue-1991864801, but this can be done independently in a follow-up PR.