### PR TITLE
Migrate away from deprecated `QuantumCircuit` methods

### DIFF
--- a/test/cutting/test_cutting_decomposition.py
+++ b/test/cutting/test_cutting_decomposition.py
@@ -137,7 +137,7 @@ class TestCuttingDecomposition(unittest.TestCase):
             )
         with self.subTest("Unsupported gate"):
             compare_circuit = QuantumCircuit(3)
-            compare_circuit.toffoli(0, 1, 2)
+            compare_circuit.ccx(0, 1, 2)
             partitions = [0, 1, 1]
             with pytest.raises(ValueError) as e_info:
                 partition_circuit_qubits(compare_circuit, partitions)
@@ -147,7 +147,7 @@ class TestCuttingDecomposition(unittest.TestCase):
             )
         with self.subTest("Toffoli gate in a single partition"):
             circuit = QuantumCircuit(4)
-            circuit.toffoli(0, 1, 2)
+            circuit.ccx(0, 1, 2)
             circuit.rzz(np.pi / 7, 2, 3)
             partition_circuit_qubits(circuit, "AAAB")
 

--- a/test/cutting/test_cutting_evaluation.py
+++ b/test/cutting/test_cutting_evaluation.py
@@ -216,7 +216,7 @@ class TestCuttingEvaluation(unittest.TestCase):
         with self.subTest("Dict of non-unique samplers"):
             qc = QuantumCircuit(2)
             qc.x(0)
-            qc.cnot(0, 1)
+            qc.cx(0, 1)
             subcircuits, _, subobservables = partition_problem(
                 circuit=qc, partition_labels="AB", observables=PauliList(["XX"])
             )

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -386,7 +386,7 @@ class TestTransforms(unittest.TestCase):
         with self.subTest("frozenset for each partition label"):
             circuit = QuantumCircuit(4)
             circuit.x(0)
-            circuit.cnot(1, 2)
+            circuit.cx(1, 2)
             circuit.h(3)
             partition_labels = [
                 frozenset([0]),
@@ -401,7 +401,7 @@ class TestTransforms(unittest.TestCase):
             compare[frozenset([0])] = QuantumCircuit(1)
             compare[frozenset([0])].x(0)
             compare[frozenset([1])] = QuantumCircuit(2)
-            compare[frozenset([1])].cnot(0, 1)
+            compare[frozenset([1])].cx(0, 1)
             compare[frozenset([2])] = QuantumCircuit(1)
             compare[frozenset([2])].h(0)
             assert separated_circuits.subcircuits.keys() == compare.keys()


### PR DESCRIPTION
Namely, the `toffoli` and `cnot` methods have been deprecated starting with Qiskit 0.45 and should be replaced with `ccx` and `cx`, respectively.