### PR TITLE
Update description of cutting tut 1

### DIFF
--- a/docs/circuit_cutting/tutorials/README.rst
+++ b/docs/circuit_cutting/tutorials/README.rst
@@ -2,8 +2,7 @@ Circuit Cutting Tutorials
 -------------------------
 
 - `Tutorial 1 <01_gate_cutting_to_reduce_circuit_width.ipynb>`__:
-  Separate sets of qubits by cutting nonlocal gates and run the
-  subexperiments for each qubit partition in parallel.
+  Separate sets of qubits by cutting nonlocal gates.
 - `Tutorial 2 <02_gate_cutting_to_reduce_circuit_depth.ipynb>`__:
   Cut gates requiring many SWAPs to decrease circuit depth.
 - `Tutorial 3 <03_wire_cutting_via_move_instruction.ipynb>`__:


### PR DESCRIPTION
The Qiskit Runtime doesn't behave well when you use primitives in parallel. The CKT tutorials which ran the circuit batches in parallel would randomly, and rather frequently, hang indefinitely. We never tracked down the cause, but we suspected the primitives were just not thread safe.

We removed the parallelization from the tutorials, but we did not update the description of tutorial 1 to reflect that. This PR updates that description.