### PR TITLE
Update ruff config

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,7 @@
 target-version = "py38"
-lint.ignore = [
+
+[lint]
+ignore = [
     "E501",  # line too long
 ]
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,9 +1,9 @@
 target-version = "py38"
-ignore = [
+lint.ignore = [
     "E501",  # line too long
 ]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "test/**.py" = [
     "F405",  # star import
     "F403",  # unable to detect undefined names due to star import


### PR DESCRIPTION
`ruff` wants us to use the `lint` package in these two spots. This PR just removes a couple of warnings from our `lint` CI job

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `.ruff.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```