### PR TITLE
Drop dependency on qiskit-algorithms

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -37,7 +37,6 @@ jobs:
           python tools/extremal-python-dependencies.py pin-dependencies \
               "qiskit @ git+https://github.com/Qiskit/qiskit.git@stable/0.46#subdirectory=qiskit_pkg" \
               "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \
-              "qiskit-algorithms @ git+https://github.com/qiskit-community/qiskit-algorithms.git" \
               --inplace
       - name: Modify tox.ini for more thorough check
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "rustworkx>=0.13.0",
     "qiskit-aer>=0.12.0",
     "qiskit>=0.45.0, <1.0",
-    "qiskit-algorithms>=0.2.1",
     "qiskit-ibm-runtime>=0.12.2",
 ]
 

--- a/releasenotes/notes/remove-forging-340dc643092a747a.yaml
+++ b/releasenotes/notes/remove-forging-340dc643092a747a.yaml
@@ -1,4 +1,4 @@
 ---
 other:
   - |
-    Removed the entanglement forging tool, as the Qiskit application modules are no longer supported, and packages in ``Qiskit-Extensions`` may not have dependency on those modules.
+    Removed the entanglement forging tool, as the Qiskit application modules are no longer supported, and packages in ``Qiskit-Extensions`` may not have dependency on those modules.  With this change, CKT no longer depends on ``qiskit-algorithms`` or Qiskit Nature.


### PR DESCRIPTION
qiskit-algorithms is no longer needed as a dependency now that entanglement forging is gone.

This is a follow up to #479.