### PR TITLE
Remove qiskit.org links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Developer guide
 
-Development of the Circuit Knitting Toolbox takes place [on GitHub](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox).  The [Contributing to Qiskit](https://qiskit.org/documentation/contributing_to_qiskit.html) guide may serve as a useful starting point, as the toolbox builds on [Qiskit] and is part of the [Qiskit Ecosystem].
+Development of the Circuit Knitting Toolbox takes place [on GitHub](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox). The [Contributing to Qiskit](https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md) guide may serve as a useful starting point, as the toolbox builds on [Qiskit] and is part of the [Qiskit Ecosystem].
 
 The toolbox is written in [Python] and uses [tox] as a testing framework.  A description of the available `tox` test environments is located at [`test/README.md`](test/README.md).  These environments are used in the CI workflows, which are described at [`.github/workflows/README.md`](.github/workflows/README.md).
 
@@ -10,8 +10,8 @@ We use [Sphinx] for documentation and [reno] for release notes.  We use [Google 
 
 We require 100% coverage in all new code.  In rare cases where it is not possible to test a code block, we mark it with ``# pragma: no cover`` so that the ``coverage`` tests will pass.
 
-[Qiskit]: https://qiskit.org/
-[Qiskit Ecosystem]: https://qiskit.org/ecosystem/
+[Qiskit]: https://www.ibm.com/quantum/qiskit
+[Qiskit Ecosystem]: https://qiskit.github.io/ecosystem/
 [Python]: https://www.python.org/
 [tox]: https://github.com/tox-dev/tox
 [Sphinx]: https://www.sphinx-doc.org/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For information on installing from source, running CKT in a container, and platf
 
 ### Deprecation Policy
 
-This project is meant to evolve rapidly and, as such, does not follow [Qiskit's deprecation policy](https://qiskit.org/documentation/contributing_to_qiskit.html#deprecation-policy).  We may occasionally make breaking changes in order to improve the user experience.  When possible, we will keep old interfaces and mark them as deprecated, as long as they can co-exist with the new ones.  Each substantial improvement, breaking change, or deprecation will be documented in the [release notes](https://qiskit-extensions.github.io/circuit-knitting-toolbox/release-notes.html).
+This project is meant to evolve rapidly and, as such, does not follow [Qiskit's deprecation policy](https://github.com/Qiskit/qiskit/blob/main/DEPRECATION.md).  We may occasionally make breaking changes in order to improve the user experience.  When possible, we will keep old interfaces and mark them as deprecated, as long as they can co-exist with the new ones.  Each substantial improvement, breaking change, or deprecation will be documented in the [release notes](https://qiskit-extensions.github.io/circuit-knitting-toolbox/release-notes.html).
 
 ----------------------------------------------------------------------------------------------------
 

--- a/docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb
+++ b/docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb
@@ -200,8 +200,8 @@
    "source": [
     "**Set up the Qiskit Runtime Service**\n",
     "\n",
-    "The Qiskit Runtime Service provides access to Qiskit Runtime Primitives and quantum backends. See the [Qiskit Runtime documentation](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/) for more information.\n",
-    "Alternatively, if a Qiskit Runtime Service is not passed, then a local statevector simulator will be used with the [Qiskit Primitives](https://qiskit.org/documentation/apidoc/primitives.html)."
+    "The Qiskit Runtime Service provides access to Qiskit Runtime Primitives and quantum backends. See the [Qiskit Runtime documentation](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/) for more information.\n",
+    "Alternatively, if a Qiskit Runtime Service is not passed, then a local statevector simulator will be used with the [Qiskit Primitives](https://docs.quantum.ibm.com/api/qiskit/primitives)."
    ]
   },
   {

--- a/docs/circuit_cutting/cutqc/tutorials/tutorial_2_manual_cutting.ipynb
+++ b/docs/circuit_cutting/cutqc/tutorials/tutorial_2_manual_cutting.ipynb
@@ -231,8 +231,8 @@
    "source": [
     "**Set up the Qiskit Runtime Service**\n",
     "\n",
-    "The Qiskit Runtime Service provides access to Qiskit Runtime Primitives and quantum backends. See the [Qiskit Runtime documentation](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/) for more information.\n",
-    "Alternatively, if a Qiskit Runtime Service is not passed, then a local statevector simulator will be used with the [Qiskit Primitives](https://qiskit.org/documentation/apidoc/primitives.html)."
+    "The Qiskit Runtime Service provides access to Qiskit Runtime Primitives and quantum backends. See the [Qiskit Runtime documentation](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/) for more information.\n",
+    "Alternatively, if a Qiskit Runtime Service is not passed, then a local statevector simulator will be used with the [Qiskit Primitives](https://docs.quantum.ibm.com/api/qiskit/primitives)."
    ]
   },
   {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,10 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
-    "qiskit-ibm-runtime": ("https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/", None),
+    "qiskit-ibm-runtime": (
+        "https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/",
+        None,
+    ),
     "qiskit-aer": ("https://qiskit.github.io/qiskit-aer/", None),
     "rustworkx": ("https://www.rustworkx.org/", None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,8 +111,8 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
-    "qiskit-ibm-runtime": ("https://qiskit.org/ecosystem/ibm-runtime/", None),
-    "qiskit-aer": ("https://qiskit.org/ecosystem/aer/", None),
-    "rustworkx": ("https://qiskit.org/ecosystem/rustworkx/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit-ibm-runtime": ("https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/", None),
+    "qiskit-aer": ("https://qiskit.github.io/qiskit-aer/", None),
+    "rustworkx": ("https://www.rustworkx.org/", None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ The toolbox currently contains the following tools:
 
 - Circuit Cutting
 
-This project is meant to evolve rapidly and, as such, does not follow `Qiskit's deprecation policy <https://qiskit.org/documentation/contributing_to_qiskit.html#deprecation-policy>`_.  We may occasionally make breaking changes in order to improve the user experience.  When possible, we will keep old interfaces and mark them as deprecated, as long as they can co-exist with the new ones.  Each substantial improvement, breaking change, or deprecation will be documented in the :ref:`release notes`.
+This project is meant to evolve rapidly and, as such, does not follow `Qiskit's deprecation policy <https://github.com/Qiskit/qiskit/blob/main/DEPRECATION.md>`_.  We may occasionally make breaking changes in order to improve the user experience.  When possible, we will keep old interfaces and mark them as deprecated, as long as they can co-exist with the new ones.  Each substantial improvement, breaking change, or deprecation will be documented in the :ref:`release notes`.
 
 Citing this project
 -------------------

--- a/releasenotes/notes/0.1/migrate-to-qiskit-nature-0.5.0-96e90cd48f36d731.yaml
+++ b/releasenotes/notes/0.1/migrate-to-qiskit-nature-0.5.0-96e90cd48f36d731.yaml
@@ -10,7 +10,7 @@ upgrade:
     as input to the ``EntanglementForgingGroundStateSolver``, rather than the deprecated ``qiskit_nature.problems.second_quantization.ElectronicStructureProblem``.
 
     For more information on migrating to Qiskit Nature 0.5, check out the
-    `Qiskit Nature migration guide <https://qiskit.org/ecosystem/nature/migration/0.5_a_intro.html>`_.
+    `Qiskit Nature migration guide <https://qiskit-community.github.io/qiskit-nature/migration/0.5_a_intro.html>`_.
 
     For more information on adapting your entanglement forging workflows, check
     out the ``tutorials <Forging tutorials>`` and ``how-to guides <Forging how-tos>``.


### PR DESCRIPTION
These links were all working okay thanks to redirects. But it's better to use the correct link directly.