### PR TITLE
Dev tests should test against qiskit `main`, not stable branch

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -31,11 +31,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip tox
           python -m pip install toml typer
-          python tools/extremal-python-dependencies.py add-dependency \
-              "qiskit @ git+https://github.com/Qiskit/qiskit.git@stable/1.0" \
-              --inplace
           python tools/extremal-python-dependencies.py pin-dependencies \
-              "qiskit @ git+https://github.com/Qiskit/qiskit.git@stable/1.0" \
+              "qiskit @ git+https://github.com/Qiskit/qiskit.git" \
               "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \
               --inplace
       - name: Modify tox.ini for more thorough check


### PR DESCRIPTION
This changes the development version tests to test against qiskit `main` (the development version) rather than `stable/1.0` (which is currently the stable version, but will not always be).  This was part of #408, which got closed out in favor of #479.