### PR TITLE
Add transpilation to cutqc evaluation

### DIFF
--- a/circuit_knitting/cutting/cutqc/wire_cutting_evaluation.py
+++ b/circuit_knitting/cutting/cutqc/wire_cutting_evaluation.py
@@ -24,6 +24,7 @@ from qiskit import QuantumCircuit
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.circuit.library.standard_gates import HGate, SGate, SdgGate, XGate
 from qiskit.primitives import BaseSampler, Sampler as TestSampler
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit_ibm_runtime import QiskitRuntimeService, Sampler, Session, Options
 
 
@@ -262,6 +263,12 @@ def run_subcircuits(
     if service is not None:
         session = Session(service=service, backend=backend_name)
         sampler = Sampler(session=session, options=options)
+        # Transpile circuits
+        backend = service.backend(session.backend())
+        pass_manager = generate_preset_pass_manager(
+            optimization_level=1, backend=backend
+        )
+        subcircuits = pass_manager.run(subcircuits)
     else:
         sampler = TestSampler(options=options)
 

--- a/docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb
+++ b/docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb
@@ -269,7 +269,7 @@
     "\n",
     "# Uncomment the following lines to instead use Qiskit Runtime Service as configured above.\n",
     "# subcircuit_instance_probabilities = evaluate_subcircuits(cuts,\n",
-    "#                                                          service_args=service.active_account(),\n",
+    "#                                                          service=service,\n",
     "#                                                          backend_names=backend_names,\n",
     "#                                                          options=options,\n",
     "#                                                         )"

--- a/docs/circuit_cutting/cutqc/tutorials/tutorial_2_manual_cutting.ipynb
+++ b/docs/circuit_cutting/cutqc/tutorials/tutorial_2_manual_cutting.ipynb
@@ -296,7 +296,7 @@
     "\n",
     "# Uncomment the following lines to instead use Qiskit Runtime Service as configured above.\n",
     "# subcircuit_instance_probabilities = evaluate_subcircuits(cuts,\n",
-    "#                                                          service_args=service.active_account(),\n",
+    "#                                                          service=service,\n",
     "#                                                          backend_names=backend_names,\n",
     "#                                                          options=options,\n",
     "#                                                         )"


### PR DESCRIPTION
Fixes #501.

I've also replaced `service_args`, which appears nowhere else in the repository, with `service`, in the notebooks.

Unfortunately, even with this change, I see the following error when I try to run the first tutorial notebook on a hardware backend:

```
File ~/circuit-knitting-toolbox/circuit_knitting/cutting/cutqc/wire_cutting_evaluation.py:236, in run_subcircuits_using_sampler(subcircuits, sampler)
    234 for i, qd in enumerate(quasi_dists):
    235     probabilities = qd.nearest_probability_distribution()
--> 236     probabilities_out = np.zeros(2 ** subcircuits[i].num_qubits, dtype=float)
    238     for state in probabilities:
    239         probabilities_out[state] = probabilities[state]

ValueError: Maximum allowed dimension exceeded
```

I think this may be unrelated to the ISA change, but it would be nice to understand.

Also, right now the options to the pass-manager (in particular, optimization level = 1) are hardcoded.  It would be possible to make this configurable, but it would involve expanding a bunch of function signatures.