### PR TITLE
Add support for `SamplerV2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   [![Release](https://img.shields.io/pypi/v/circuit-knitting-toolbox.svg?label=Release)](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/releases)
   ![Platform](https://img.shields.io/badge/%F0%9F%92%BB%20Platform-Linux%20%7C%20macOS%20%7C%20Windows-informational)
   [![Python](https://img.shields.io/pypi/pyversions/circuit-knitting-toolbox?label=Python&logo=python)](https://www.python.org/)
-  [![Qiskit](https://img.shields.io/badge/Qiskit%20-%20%3E%3D0.46%20-%20%236133BD?logo=Qiskit)](https://github.com/Qiskit/qiskit)
+  [![Qiskit](https://img.shields.io/badge/Qiskit%20-%20%3E%3D1.0%20-%20%236133BD?logo=Qiskit)](https://github.com/Qiskit/qiskit)
 <br />
   [![Docs (stable)](https://img.shields.io/badge/%F0%9F%93%84%20Docs-stable-blue.svg)](https://qiskit-extensions.github.io/circuit-knitting-toolbox/)
   [![DOI](https://zenodo.org/badge/543181258.svg)](https://zenodo.org/badge/latestdoi/543181258)

--- a/circuit_knitting/cutting/cutting_reconstruction.py
+++ b/circuit_knitting/cutting/cutting_reconstruction.py
@@ -17,7 +17,10 @@ from collections.abc import Sequence, Hashable
 
 import numpy as np
 from qiskit.quantum_info import PauliList
-from qiskit.primitives import SamplerResult
+from qiskit.primitives import (
+    SamplerResult,  # for SamplerV1
+    PrimitiveResult,  # for SamplerV2
+)
 
 from ..utils.observable_grouping import CommutingObservableGroup, ObservableCollection
 from ..utils.bitwise import bit_count
@@ -27,7 +30,11 @@ from .qpd import WeightType
 
 
 def reconstruct_expectation_values(
-    results: SamplerResult | dict[Hashable, SamplerResult],
+    results: (
+        SamplerResult
+        | PrimitiveResult
+        | dict[Hashable, SamplerResult | PrimitiveResult]
+    ),
     coefficients: Sequence[tuple[float, WeightType]],
     observables: PauliList | dict[Hashable, PauliList],
 ) -> list[float]:
@@ -68,9 +75,11 @@ def reconstruct_expectation_values(
         ValueError: ``observables`` and ``results`` are of incompatible types.
         ValueError: An input observable has a phase not equal to 1.
     """
-    if isinstance(observables, PauliList) and not isinstance(results, SamplerResult):
+    if isinstance(observables, PauliList) and not isinstance(
+        results, (SamplerResult, PrimitiveResult)
+    ):
         raise ValueError(
-            "If observables is a PauliList, results must be a SamplerResult instance."
+            "If observables is a PauliList, results must be a SamplerResult or PrimitiveResult instance."
         )
     if isinstance(observables, dict) and not isinstance(results, dict):
         raise ValueError(
@@ -84,7 +93,7 @@ def reconstruct_expectation_values(
         subobservables_by_subsystem = decompose_observables(
             observables, "A" * len(observables[0])
         )
-        results_dict: dict[Hashable, SamplerResult] = {"A": results}
+        results_dict: dict[Hashable, SamplerResult | PrimitiveResult] = {"A": results}
         expvals = np.zeros(len(observables))
 
     else:
@@ -107,10 +116,28 @@ def reconstruct_expectation_values(
             subsystem_expvals = [
                 np.zeros(len(cog.commuting_observables)) for cog in so.groups
             ]
+            current_result = results_dict[label]
             for k, cog in enumerate(so.groups):
-                quasi_probs = results_dict[label].quasi_dists[i * len(so.groups) + k]
-                for outcome, quasi_prob in quasi_probs.items():
-                    subsystem_expvals[k] += quasi_prob * _process_outcome(cog, outcome)
+                idx = i * len(so.groups) + k
+                if isinstance(current_result, SamplerResult):
+                    # SamplerV1 provides a SamplerResult
+                    quasi_probs = current_result.quasi_dists[idx]
+                    for outcome, quasi_prob in quasi_probs.items():
+                        subsystem_expvals[k] += quasi_prob * _process_outcome(
+                            cog, outcome
+                        )
+                else:
+                    # SamplerV2 provides a PrimitiveResult
+                    data_pub = current_result[idx].data
+                    qpd_array = data_pub.qpd_measurements.array
+                    obs_array = data_pub.observable_measurements.array
+                    shots = qpd_array.shape[0]
+                    for j in range(shots):
+                        meas_outcomes = int.from_bytes(obs_array[j], "big")
+                        qpd_outcomes = int.from_bytes(qpd_array[j], "big")
+                        subsystem_expvals[k] += (1 / shots) * _process_outcome_v2(
+                            cog, meas_outcomes, qpd_outcomes
+                        )
 
             for k, subobservable in enumerate(subobservables_by_subsystem[label]):
                 current_expvals[k] *= np.mean(
@@ -143,6 +170,12 @@ def _process_outcome(
     meas_outcomes = outcome & ((1 << num_meas_bits) - 1)
     qpd_outcomes = outcome >> num_meas_bits
 
+    return _process_outcome_v2(cog, meas_outcomes, qpd_outcomes)
+
+
+def _process_outcome_v2(
+    cog: CommutingObservableGroup, meas_outcomes: int, qpd_outcomes: int, /
+) -> np.typing.NDArray[np.float64]:
     # qpd_factor will be -1 or +1, depending on the overall parity of qpd
     # measurements.
     qpd_factor = 1 - 2 * (bit_count(qpd_outcomes) & 1)

--- a/circuit_knitting/cutting/cutting_reconstruction.py
+++ b/circuit_knitting/cutting/cutting_reconstruction.py
@@ -126,7 +126,7 @@ def reconstruct_expectation_values(
                         subsystem_expvals[k] += quasi_prob * _process_outcome(
                             cog, outcome
                         )
-                else:
+                else:  # pragma: no cover
                     # SamplerV2 provides a PrimitiveResult
                     data_pub = current_result[idx].data
                     qpd_array = data_pub.qpd_measurements.array

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "rustworkx>=0.14.0",
     "qiskit-aer>=0.13.3",
     "qiskit>=1.0.0, <2.0",
-    "qiskit-ibm-runtime>=0.21.2",
+    "qiskit-ibm-runtime>=0.21.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numpy>=1.23.0",
     "scipy>=1.5.2",
     "rustworkx>=0.14.0",
-    "qiskit-aer>=0.13.0",
+    "qiskit-aer>=0.13.3",
     "qiskit>=1.0.0, <2.0",
     "qiskit-ibm-runtime>=0.21.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ test = [
 ]
 nbtest = [
     "circuit-knitting-toolbox[basetest]",
-    "nbmake>=1.3.4"
+    "nbmake>=1.4.3"
 ]
 style = [
     "autoflake==2.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "scipy>=1.5.2",
     "rustworkx>=0.14.0",
     "qiskit-aer>=0.12.0",
-    "qiskit @ git+https://github.com/Qiskit/qiskit.git",
+    "qiskit @ git+https://github.com/garrison/qiskit-terra.git@backendsamplerv2-empty-creg",
     "qiskit-ibm-runtime>=0.21.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
     "scipy>=1.5.2",
     "rustworkx>=0.14.0",
     "qiskit-aer>=0.12.0",
-    "qiskit>=0.46.0, <2.0",
-    "qiskit-ibm-runtime>=0.12.2",
+    "qiskit @ git+https://github.com/Qiskit/qiskit.git",
+    "qiskit-ibm-runtime>=0.21.0",
 ]
 
 [project.optional-dependencies]
@@ -115,3 +115,6 @@ remove-all-unused-imports = true
 testpaths = ["./circuit_knitting/", "./test/"]
 filterwarnings = ["ignore:::.*qiskit.opflow*"]
 addopts = "--doctest-modules -rs --durations=10"
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "scipy>=1.5.2",
     "rustworkx>=0.14.0",
     "qiskit-aer>=0.13.0",
-    "qiskit>=0.46.0, <2.0",
+    "qiskit>=1.0.0, <2.0",
     "qiskit-ibm-runtime>=0.21.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "rustworkx>=0.14.0",
     "qiskit-aer>=0.13.3",
     "qiskit>=1.0.0, <2.0",
-    "qiskit-ibm-runtime>=0.21.0",
+    "qiskit-ibm-runtime>=0.21.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
     "numpy>=1.23.0",
     "scipy>=1.5.2",
     "rustworkx>=0.14.0",
-    "qiskit-aer>=0.12.0",
-    "qiskit @ git+https://github.com/garrison/qiskit-terra.git@backendsamplerv2-empty-creg",
+    "qiskit-aer>=0.13.0",
+    "qiskit>=0.46.0, <2.0",
     "qiskit-ibm-runtime>=0.21.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,3 @@ remove-all-unused-imports = true
 testpaths = ["./circuit_knitting/", "./test/"]
 filterwarnings = ["ignore:::.*qiskit.opflow*"]
 addopts = "--doctest-modules -rs --durations=10"
-
-[tool.hatch.metadata]
-allow-direct-references = true

--- a/releasenotes/notes/bump-dependency-versions-d5dc3b10ba842f2d.yaml
+++ b/releasenotes/notes/bump-dependency-versions-d5dc3b10ba842f2d.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    CKT now requires ``qiskit`` 1.0 or later, ``qiskit-aer`` 0.13.3
+    or later, and ``qiskit-ibm-runtime`` 0.21.0 or later.

--- a/releasenotes/notes/bump-dependency-versions-d5dc3b10ba842f2d.yaml
+++ b/releasenotes/notes/bump-dependency-versions-d5dc3b10ba842f2d.yaml
@@ -1,5 +1,6 @@
 ---
 upgrade:
   - |
-    CKT now requires ``qiskit`` 1.0 or later, ``qiskit-aer`` 0.13.3
-    or later, and ``qiskit-ibm-runtime`` 0.21.0 or later.
+    CKT now requires updated versions of some dependencies: ``qiskit``
+    1.0 or later, ``qiskit-aer`` 0.13.3 or later, and
+    ``qiskit-ibm-runtime`` 0.21.0 or later.

--- a/releasenotes/notes/cutting-samplerv2-603b0c631a3330df.yaml
+++ b/releasenotes/notes/cutting-samplerv2-603b0c631a3330df.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Circuit cutting reconstruction can now interpret the
+    :class:`~qiskit.primitives.PrimitiveResult` object, which is
+    returned by version 2 of the sampler primitive
+    (:class:`~qiskit.primitives.BaseSamplerV2`).  See the `migration guide
+    <https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0-features#qiskitprimitives>`__
+    for details on upgrading to version 2 of the Qiskit primitives.

--- a/test/cutting/test_cutting_reconstruction.py
+++ b/test/cutting/test_cutting_reconstruction.py
@@ -15,11 +15,14 @@ from ddt import ddt, data, unpack
 import pytest
 import numpy as np
 from qiskit.result import QuasiDistribution
-from qiskit.primitives import SamplerResult
-
-# TODO: PrimitiveResult test in this file
+from qiskit.primitives import (
+    SamplerResult,
+    PrimitiveResult,
+    PubResult,
+    BitArray,
+)
+from qiskit.primitives.containers import make_data_bin
 from qiskit.quantum_info import Pauli, PauliList
-from qiskit.circuit import QuantumCircuit, ClassicalRegister
 
 from circuit_knitting.utils.observable_grouping import CommutingObservableGroup
 from circuit_knitting.cutting.qpd import WeightType
@@ -42,11 +45,6 @@ class TestCuttingReconstruction(unittest.TestCase):
                 quasi_dists=[QuasiDistribution({"0": 1.0})], metadata=[{}]
             )
             weights = [(1.0, WeightType.EXACT)]
-            subexperiments = [QuantumCircuit(2)]
-            creg1 = ClassicalRegister(2, name="observable_measurements")
-            creg2 = ClassicalRegister(1, name="qpd_measurements")
-            subexperiments[0].add_register(creg1)
-            subexperiments[0].add_register(creg2)
             observables = PauliList(["ZZ"])
             expvals = reconstruct_expectation_values(results, weights, observables)
             self.assertEqual([1.0], expvals)
@@ -55,7 +53,6 @@ class TestCuttingReconstruction(unittest.TestCase):
                 quasi_dists=[QuasiDistribution({"0": 1.0})], metadata=[{}]
             )
             weights = [(0.5, WeightType.EXACT), (0.5, WeightType.EXACT)]
-            subexperiments = {"A": QuantumCircuit(2)}
             observables = {"A": PauliList(["Z"]), "B": PauliList(["Z"])}
             with pytest.raises(ValueError) as e_info:
                 reconstruct_expectation_values(results, weights, observables)
@@ -76,11 +73,6 @@ class TestCuttingReconstruction(unittest.TestCase):
                 quasi_dists=[QuasiDistribution({"0": 1.0})], metadata=[{}]
             )
             weights = [(0.5, WeightType.EXACT)]
-            subexperiments = [QuantumCircuit(2)]
-            creg1 = ClassicalRegister(2, name="observable_measurements")
-            creg2 = ClassicalRegister(1, name="qpd_measurements")
-            subexperiments[0].add_register(creg1)
-            subexperiments[0].add_register(creg2)
             observables = PauliList(["iZZ"])
             with pytest.raises(ValueError) as e_info:
                 reconstruct_expectation_values(results, weights, observables)
@@ -89,7 +81,6 @@ class TestCuttingReconstruction(unittest.TestCase):
                 == "An input observable has a phase not equal to 1."
             )
             results = {"A": results}
-            subexperiments = {"A": subexperiments}
             observables = {"A": observables}
             with pytest.raises(ValueError) as e_info:
                 reconstruct_expectation_values(results, weights, observables)
@@ -97,6 +88,28 @@ class TestCuttingReconstruction(unittest.TestCase):
                 e_info.value.args[0]
                 == "An input observable has a phase not equal to 1."
             )
+        with self.subTest("Test SamplerV2 result"):
+            data_bin_cls = make_data_bin(
+                [("observable_measurements", BitArray), ("qpd_measurements", BitArray)],
+                shape=(),
+            )
+            obs_data = BitArray(
+                np.array([0, 0, 0, 1, 0, 0, 2, 3, 1, 0], dtype=np.uint8).reshape(-1, 1),
+                2,
+            )
+            qpd_data = BitArray(
+                np.array([0, 1, 1, 3, 2, 0, 1, 3, 0, 2], dtype=np.uint8).reshape(-1, 1),
+                2,
+            )
+            data_bin = data_bin_cls(
+                observable_measurements=obs_data, qpd_measurements=qpd_data
+            )
+            pub_result = PubResult(data_bin)
+            results = PrimitiveResult([pub_result])
+            weights = [(1.0, WeightType.EXACT)]
+            observables = PauliList(["II", "IZ", "ZI", "ZZ"])
+            expvals = reconstruct_expectation_values(results, weights, observables)
+            assert expvals == pytest.approx([0.0, -0.6, 0.0, -0.2])
 
     @data(
         ("000", [1, 1, 1]),

--- a/test/cutting/test_cutting_reconstruction.py
+++ b/test/cutting/test_cutting_reconstruction.py
@@ -16,6 +16,8 @@ import pytest
 import numpy as np
 from qiskit.result import QuasiDistribution
 from qiskit.primitives import SamplerResult
+
+# TODO: PrimitiveResult test in this file
 from qiskit.quantum_info import Pauli, PauliList
 from qiskit.circuit import QuantumCircuit, ClassicalRegister
 
@@ -67,7 +69,7 @@ class TestCuttingReconstruction(unittest.TestCase):
                 reconstruct_expectation_values(results2, weights, observables)
             assert (
                 e_info.value.args[0]
-                == "If observables is a PauliList, results must be a SamplerResult instance."
+                == "If observables is a PauliList, results must be a SamplerResult or PrimitiveResult instance."
             )
         with self.subTest("Test unsupported phase"):
             results = SamplerResult(

--- a/test/cutting/test_cutting_workflows.py
+++ b/test/cutting/test_cutting_workflows.py
@@ -20,7 +20,9 @@ from qiskit.circuit.library import EfficientSU2, CXGate
 from qiskit.quantum_info import PauliList
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.providers.fake_provider import GenericBackendV2
+from qiskit.primitives import BackendSamplerV2
 from qiskit_aer.primitives import Sampler
+from qiskit_aer import AerSimulator
 
 from circuit_knitting.cutting.qpd.instructions import SingleQubitQPDGate
 from circuit_knitting.cutting.qpd import QPDBasis
@@ -180,3 +182,54 @@ def test_wire_cut_workflow_with_reused_qubits():
         assert subexpt.count_ops()["reset"] == 1
     for subexpt in subexperiments["B"]:
         assert "reset" not in subexpt.count_ops()
+
+
+def test_reconstruction_with_samplerv2():
+    """Smoke test for reconstruction using samplerv2"""
+    qc = QuantumCircuit(4)
+    qc.h(range(4))
+    qc.ryy(0.1, 1, 2)
+    qc.h(range(4))
+
+    observables = PauliList(["ZIII", "IZII", "IIZI", "IIIZ"])
+
+    partitioned_problem = partition_problem(
+        circuit=qc, partition_labels=[0, 0, 1, 1], observables=observables
+    )
+
+    subexperiments, coefficients = generate_cutting_experiments(
+        circuits=partitioned_problem.subcircuits,
+        observables=partitioned_problem.subobservables,
+        num_samples=100,
+    )
+
+    # Filter out any subexperiment where any classical register has zero bits.
+    # This is a workaround for https://github.com/Qiskit/qiskit/issues/12043.
+    for label in subexperiments.keys():
+        subexperiments[label] = [
+            subexpt
+            for subexpt in subexperiments[label]
+            if all(creg.size > 0 for creg in subexpt.cregs)
+        ]
+    # Ensure we did not just filter out _everything_.
+    assert len(subexperiments) > 0
+
+    # Use BackendSamplerV2 with AerSimulator, following
+    # https://github.com/Qiskit/qiskit-aer/issues/2078#issuecomment-1971498534
+    samplers = {
+        label: BackendSamplerV2(backend=AerSimulator())
+        for label in subexperiments.keys()
+    }
+    results = {
+        label: sampler.run(subexperiments[label], shots=128).result()
+        for label, sampler in samplers.items()
+    }
+
+    # Smoke test of reconstruction
+    reconstructed_expvals = reconstruct_expectation_values(
+        results,
+        coefficients,
+        partitioned_problem.subobservables,
+    )
+
+    assert len(reconstructed_expvals) == len(observables)


### PR DESCRIPTION
Fixes #488.

This ~~is waiting on~~ requires one of the following before we can move forward (EDIT: the first item is now done!).
- Qiskit fix to https://github.com/Qiskit/qiskit/issues/12043
- Qiskit Aer release containing https://github.com/Qiskit/qiskit-aer/issues/2078

To-do list:
- [x] release note
- [x] `PrimitiveResult` test in `test/cutting/test_cutting_reconstruction.py`
- [x] update qiskit version in readme badge
- [x] test the first tutorial notebook locally using the SamplerV2 primitive from Qiskit Runtime.