### PR TITLE
Lower the nbmake cell timeout to 5 minutes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ extras =
   nbtest
   notebook-dependencies
 commands =
-  pytest --nbmake --nbmake-timeout=3000 {posargs} docs/ --ignore=docs/_build
+  pytest --nbmake --nbmake-timeout=300 {posargs} docs/ --ignore=docs/_build
 
 [testenv:coverage]
 basepython = python3.10


### PR DESCRIPTION
This should help with tracking down the intermittent CI failures in the notebook tests.

I will merge this as soon as CI passes.