### PR TITLE
Update cutqc tutorials index with deprecated status

### DIFF
--- a/docs/circuit_cutting/cutqc/index.rst
+++ b/docs/circuit_cutting/cutqc/index.rst
@@ -6,7 +6,7 @@ The ``cutqc`` module implements the wire cutting technique and
 automatic cut finding method described in the research paper
 `arXiv:2012.02333 <https://arxiv.org/abs/2012.02333>`_.  Historically,
 this was the original circuit cutting implementation in the Circuit
-Knitting Toolbox.  Going forward, this module is deprecated.  New users
+Knitting Toolbox.  Going forward, this module is deprecated.  Users
 of the toolbox should use the new circuit cutting interface, instead.
 
 .. _cutqc tutorials:

--- a/docs/circuit_cutting/cutqc/index.rst
+++ b/docs/circuit_cutting/cutqc/index.rst
@@ -6,14 +6,8 @@ The ``cutqc`` module implements the wire cutting technique and
 automatic cut finding method described in the research paper
 `arXiv:2012.02333 <https://arxiv.org/abs/2012.02333>`_.  Historically,
 this was the original circuit cutting implementation in the Circuit
-Knitting Toolbox.  Going forward, this module is considered legacy
-code that is supported, but new features are not expected.  New users
-of the toolbox should use the new circuit cutting interface, instead,
-unless they specifically need a feature that is not (yet) supported by
-the new code.  These features currently specific to ``cutqc`` include:
-
-- Reconstruction of probability distributions (rather than expectation values)
-- Automatic cut finding
+Knitting Toolbox.  Going forward, this module is deprecated.  New users
+of the toolbox should use the new circuit cutting interface, instead.
 
 .. _cutqc tutorials:
 

--- a/docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb
+++ b/docs/circuit_cutting/cutqc/tutorials/tutorial_1_automatic_cut_finding.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# CutQC Tutorial 1: Circuit Cutting with Automatic Cut Finding\n",
     "\n",
+    "**NOTE: CutQC is deprecated and will be removed no sooner than Circuit Knitting Toolbox v0.8.0.  The circuit cutting workflow in `circuit_knitting.cutting` now implements similar and improved functionalities, which will be maintained going forward.**\n",
+    "\n",
     "Circuit cutting is a technique to decompose a quantum circuit into smaller circuits, whose results can be knitted together to reconstruct the original circuit output. \n",
     "\n",
     "The circuit knitting toolbox implements a wire cutting method presented in [CutQC](https://doi.org/10.1145/3445814.3446758) (Tang et al.). This method allows a circuit wire to be cut such that the generated subcircuits are amended by measurements in the Pauli bases and by state preparation of four Pauli eigenstates (see Fig. 4 of [CutQC](https://doi.org/10.1145/3445814.3446758)).\n",

--- a/docs/circuit_cutting/cutqc/tutorials/tutorial_2_manual_cutting.ipynb
+++ b/docs/circuit_cutting/cutqc/tutorials/tutorial_2_manual_cutting.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# CutQC Tutorial 2: Circuit Cutting with Manual Wire Cutting\n",
     "\n",
+    "**NOTE: CutQC is deprecated and will be removed no sooner than Circuit Knitting Toolbox v0.8.0.  The circuit cutting workflow in `circuit_knitting.cutting` now implements similar and improved functionalities, which will be maintained going forward.**\n",
+    "\n",
     "Circuit cutting is a technique to decompose a quantum circuit into smaller circuits, whose results can be knitted together to reconstruct the original circuit output. \n",
     "\n",
     "The circuit knitting toolbox implements a wire cutting method presented in [CutQC](https://doi.org/10.1145/3445814.3446758) (Tang et al.). This method allows a circuit wire to be cut such that the generated subcircuits are amended by measurements in the Pauli bases and by state preparation of four Pauli eigenstates (see Fig. 4 of [CutQC](https://doi.org/10.1145/3445814.3446758)).\n",


### PR DESCRIPTION
This is a follow-up to #527.  Marking as a draft because it might be worth putting other updates of places we missed as we discover them.

#### To do

- [x] make sure the deprecation warning appears somehow in each cutqc tutorial (heh, even with #534 this is still necessary because the `%%capture` in the first `cutqc` import in each tutorial suppresses the `DeprecationWarning`).