### PR TITLE
RFC: Re-execute notebooks on CI when building Sphinx docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ Sphinx documentation builder
 
 # General options:
 from pathlib import Path
+import os
 import sys
 
 from importlib.metadata import version as metadata_version
@@ -88,7 +89,7 @@ autoclass_content = "both"
 
 # nbsphinx options (for tutorials)
 nbsphinx_timeout = 180
-nbsphinx_execute = "auto"
+nbsphinx_execute = "always" if os.environ.get("CI") == "true" else "auto"
 nbsphinx_widgets_path = ""
 exclude_patterns = [
     "_build",

--- a/tox.ini
+++ b/tox.ini
@@ -62,3 +62,5 @@ commands =
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "stubs", ignore_errors=True)'
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "_build" / "html" / ".doctrees", ignore_errors=True)'
   sphinx-build -j auto -W -T --keep-going {posargs} docs/ docs/_build/html
+passenv =
+  CI


### PR DESCRIPTION
Currently, we have set `nbsphinx_execute = "auto"` in the Sphinx configuration so that [notebooks are _not_ re-executed](https://nbsphinx.readthedocs.io/en/0.9.3/never-execute.html) anytime someone runs `tox -e docs`, in large part to speed up the build cycle for quick development.

However, even without changing this for local builds, we have the option of changing this on CI, which is where our deployed documentation is built.

Here's what would be different:
- The notebooks in the docs will always be the result of a fresh run, so we will no longer to be forced to manually re-execute notebooks e.g., anytime the Qiskit default visualizaions change (#524) or  when deprecation warnings are added to our own codebase (possible part of #533), etc.
- We will have less control about what output is appearing in the hosted notebooks.  Maybe something weird will happen because of a weird random seed.  (For the docs to build and deploy successfully, the code must execute without errors, but there could still be something weird in the notebook short of an actual failure.)  Conversely, if running a notebook _does_ result in something weird, I'd almost prefer that that is visible to at least us as we glance through the documentation, rather than be something that is not discovered until a user actually tries to use the notebook.

I'm not really sure which I'd prefer, but think it is worth considering merging this.  Open to discussion.