### PR TITLE
Add github button to docs homepage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Contents
 
   API References <apidocs/index>
   Release Notes <release-notes>
+  Github <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox>
 
 .. Hiding - Indices and tables
    :ref:`genindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ Contents
 
   API References <apidocs/index>
   Release Notes <release-notes>
-  Github <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox>
+  GitHub <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox>
 
 .. Hiding - Indices and tables
    :ref:`genindex`


### PR DESCRIPTION
If I end up at a software package's docs page before their Github repo, it is nice to be able to get directly to the Github repo from there. I find github repos can often be more difficult to find on search engines than docs pages

We have a small button which shows our stars and links users to Github. I think that is great, and I think we can also just add a button to our toolbar that takes people there.

This is personal preference, but this is something I personally think is worth having if your homescreen toolbar isn't already crowded