### PR TITLE
Adjust docs artifact filename

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,12 +37,18 @@ jobs:
         shell: bash
         run: |
           tox -edocs
+      - name: Prepare docs artifact
+        if: always()
+        shell: bash
+        run: |
+          mkdir artifact
+          cp -a docs/_build/html artifact/ckt_html_docs
       - name: Upload docs artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: html_docs
-          path: ./docs/_build/html
+          name: ckt_html_docs
+          path: ./artifact
       - name: Deploy docs
         if: ${{ github.ref == 'refs/heads/stable/0.6' }}
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
I've been referencing the documentation artifact a lot lately.   It'd be nice to have better filenames to work with.

Formerly: `html_docs.zip` extracted directly to the current directory.

With this PR: `ckt_html_docs.zip` extracts everything to a single subdirectory called `ckt_html_docs`.