### PR TITLE
Move pylint configuration to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,22 @@ only-include = [
 remove-unused-variables = true
 remove-all-unused-imports = true
 
+[tool.pylint.main]
+py-version = "3.8"
+disable = "all"
+enable = [
+    "reimported",
+    "no-self-use",
+    "no-else-raise",
+    "redefined-argument-from-local",
+    "redefined-builtin",
+    "raise-missing-from",
+    "cyclic-import",
+    "unused-argument",
+    "use-list-literal",
+    "use-dict-literal",
+]
+
 #[tool.coverage.run]
 #omit = [
 #    # deprecated import location(s)

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,8 @@ commands =
   pydocstyle circuit_knitting/
   mypy circuit_knitting/
   reno lint
-  pylint -rn --py-version=3.8 --disable=all --enable=reimported,no-self-use,no-else-raise,redefined-argument-from-local,redefined-builtin,raise-missing-from,cyclic-import,unused-argument,use-list-literal,use-dict-literal circuit_knitting/ test/ tools/
-  nbqa pylint -rn --py-version=3.8 --disable=all --enable=reimported,no-self-use,no-else-raise,redefined-argument-from-local,redefined-builtin,raise-missing-from,cyclic-import,unused-argument,use-list-literal,use-dict-literal docs/
+  pylint -rn circuit_knitting/ test/ tools/
+  nbqa pylint -rn docs/
 
 [testenv:{,py-,py3-,py38-,py39-,py310-,py311-,py312-}notebook]
 extras =


### PR DESCRIPTION
This removes the super-long lines for `tox.ini`, and prepares us to enable some additional rules.

This seems like a no-brainer, so I plan to merge this as soon as CI passes.