### PR TITLE
Enable pylint's `dangerous-default-value` check

### DIFF
--- a/circuit_knitting/cutting/cut_finding/circuit_interface.py
+++ b/circuit_knitting/cutting/cut_finding/circuit_interface.py
@@ -158,7 +158,7 @@ class SimpleGateList(CircuitInterface):
     def __init__(
         self,
         input_circuit: list[CircuitElement | str],
-        init_qubit_names: list[Hashable] = [],
+        init_qubit_names: Sequence[Hashable] = (),
     ):
         """Assign member variables."""
         self.qubit_names = NameToIDMap(init_qubit_names)
@@ -410,7 +410,7 @@ class SimpleGateList(CircuitInterface):
 class NameToIDMap:
     """Class used to construct maps between hashable items (e.g., qubit names) and natural numbers (e.g., qubit IDs)."""
 
-    def __init__(self, init_names: list[Hashable]):
+    def __init__(self, init_names: Sequence[Hashable]):
         """Allow the name dictionary to be initialized with the names in ``init_names`` in the order the names appear.
 
         This is done in order to force a preferred ordering in the assigment of item IDs to those names.

--- a/circuit_knitting/cutting/cut_finding/circuit_interface.py
+++ b/circuit_knitting/cutting/cut_finding/circuit_interface.py
@@ -136,10 +136,10 @@ class SimpleGateList(CircuitInterface):
     `cut_type` (list): a list that assigns cut-type annotations to gates
     in ``new_circuit``.
 
-    `new_gate_ID`_map (list): a list that maps the positions of gates
+    `new_gate_ID`_map (array): an array that maps the positions of gates
     in circuit to their new positions in ``new_circuit``.
 
-    `output_wires` (list): a list that maps qubit IDs in circuit to the corresponding
+    `output_wires` (array): an array that maps qubit IDs in circuit to the corresponding
     output wires of new_circuit so that observables defined for circuit
     can be remapped to ``new_circuit``.
 

--- a/circuit_knitting/cutting/cut_finding/cut_optimization.py
+++ b/circuit_knitting/cutting/cut_finding/cut_optimization.py
@@ -195,14 +195,18 @@ class CutOptimization:
         circuit_interface,
         optimization_settings,
         device_constraints,
-        search_engine_config={
-            "CutOptimization": SearchSpaceGenerator(
-                functions=cut_optimization_search_funcs,
-                actions=disjoint_subcircuit_actions,
-            )
-        },
+        search_engine_config=None,
     ):
         """Assign member variables."""
+        if search_engine_config is None:
+            # Set default config
+            search_engine_config = {
+                "CutOptimization": SearchSpaceGenerator(
+                    functions=cut_optimization_search_funcs,
+                    actions=disjoint_subcircuit_actions,
+                )
+            }
+
         generator = search_engine_config["CutOptimization"]
         search_space_funcs = generator.functions
         search_space_actions = generator.actions

--- a/circuit_knitting/cutting/cut_finding/lo_cuts_optimizer.py
+++ b/circuit_knitting/cutting/cut_finding/lo_cuts_optimizer.py
@@ -65,14 +65,18 @@ class LOCutsOptimizer:
         circuit_interface=None,
         optimization_settings=None,
         device_constraints=None,
-        search_engine_config={
-            "CutOptimization": SearchSpaceGenerator(
-                functions=cut_optimization_search_funcs,
-                actions=disjoint_subcircuit_actions,
-            )
-        },
+        search_engine_config=None,
     ):
         """Initialize :class:`LOCutsOptimizer with the specified configuration variables."""
+        if search_engine_config is None:
+            # Set default config
+            search_engine_config = {
+                "CutOptimization": SearchSpaceGenerator(
+                    functions=cut_optimization_search_funcs,
+                    actions=disjoint_subcircuit_actions,
+                )
+            }
+
         self.circuit_interface = circuit_interface
         self.optimization_settings = optimization_settings
         self.device_constraints = device_constraints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ enable = [
     "unused-argument",
     "use-list-literal",
     "use-dict-literal",
+    "dangerous-default-value",
 ]
 
 #[tool.coverage.run]

--- a/test/cutting/cut_finding/test_circuit_interfaces.py
+++ b/test/cutting/cut_finding/test_circuit_interfaces.py
@@ -68,7 +68,7 @@ class TestCircuitInterface:
         assert max_wire_cuts_gamma(7) == 2
 
         # Assign by hand a different qubit mapping by specifiying init_qubit_names.
-        circuit_converted = SimpleGateList(trial_circuit, ("q0", "q1"))
+        circuit_converted = SimpleGateList(trial_circuit, ["q0", "q1"])
         assert circuit_converted.qubit_names.item_dict == {"q0": 0, "q1": 1}
         assert circuit_converted.circuit == [
             [CircuitElement(name="h", params=[], qubits=[1], gamma=None), None],

--- a/test/cutting/cut_finding/test_circuit_interfaces.py
+++ b/test/cutting/cut_finding/test_circuit_interfaces.py
@@ -68,7 +68,7 @@ class TestCircuitInterface:
         assert max_wire_cuts_gamma(7) == 2
 
         # Assign by hand a different qubit mapping by specifiying init_qubit_names.
-        circuit_converted = SimpleGateList(trial_circuit, ["q0", "q1"])
+        circuit_converted = SimpleGateList(trial_circuit, ("q0", "q1"))
         assert circuit_converted.qubit_names.item_dict == {"q0": 0, "q1": 1}
         assert circuit_converted.circuit == [
             [CircuitElement(name="h", params=[], qubits=[1], gamma=None), None],


### PR DESCRIPTION
When I ran pylint in its default configuration, I noticed a few `dangerous-default-value` warnings in the new cut finder.  I think it's worth adding this to our pylint configuration and fixing the existing issues in the code base.  (Even though users aren't supposed to directly call this code, adding this to our config allows us to prevent similar dangerous defaults in places we _do_ care about.)