### PR TITLE
Fix hyper-specific import of `qiskit.synthesis.TwoQubitWeylDecomposition`

### DIFF
--- a/circuit_knitting/cutting/qpd/decompositions.py
+++ b/circuit_knitting/cutting/qpd/decompositions.py
@@ -57,7 +57,7 @@ from qiskit.circuit.library.standard_gates import (
     iSwapGate,
     DCXGate,
 )
-from qiskit.synthesis.two_qubit.two_qubit_decompose import TwoQubitWeylDecomposition
+from qiskit.synthesis import TwoQubitWeylDecomposition
 
 from .qpd_basis import QPDBasis
 from .instructions import QPDMeasure


### PR DESCRIPTION
This is a follow-up to the conversation at https://github.com/Qiskit/qiskit/pull/11635#issuecomment-1915535406.

The toplevel package import was made available in https://github.com/Qiskit/qiskit/pull/11687 in time for Qiskit 1.0.

I plan to merge once CI passes.