### PR TITLE
Fix docs errors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,11 @@ jobs:
           pip install tox
           sudo apt-get update
           sudo apt-get install -y pandoc
+      - name: Temporary workaround for GitVersion
+        shell: bash
+        run: |
+          git config --unset-all extensions.worktreeconfig
+          # See https://github.com/GitTools/actions/issues/1115
       - name: Tell reno to name the upcoming release after the branch we are on
         shell: bash
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
+      - name: Temporary workaround for GitVersion
+        shell: bash
+        run: |
+          git config --unset-all extensions.worktreeconfig
+          # See https://github.com/GitTools/actions/issues/1115
       - name: Run styles check
         shell: bash
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ lint = [
     "circuit-knitting-toolbox[style]",
     "pydocstyle==6.3.0",
     "mypy==1.9.0",
-    "reno>=3.4.0",
+    "reno>=3.4.0, <4",
     "pylint==3.1.0",
     # pydocstyle prefers to parse our pyproject.toml, hence the following line
     "toml",

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,6 @@ extras =
 commands =
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "stubs", ignore_errors=True)'
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "_build" / "html" / ".doctrees", ignore_errors=True)'
-  sphinx-build -j auto -W -T --keep-going {posargs} docs/ docs/_build/html
+  sphinx-build -j 1 -W -T --keep-going {posargs} docs/ docs/_build/html
 passenv =
   CI

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,6 @@ extras =
 commands =
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "stubs", ignore_errors=True)'
   python -c 'import shutil, pathlib; shutil.rmtree(pathlib.Path("docs") / "_build" / "html" / ".doctrees", ignore_errors=True)'
-  sphinx-build -j 1 -W -T --keep-going {posargs} docs/ docs/_build/html
+  sphinx-build -j auto -W -T --keep-going {posargs} docs/ docs/_build/html
 passenv =
   CI


### PR DESCRIPTION
Fixes #557 

There is a problem with `dulwich` (used by `reno`) and `git worktrees`. This PR implements a temporary fix, spelled out [here](https://github.com/GitTools/actions/issues/1115#issuecomment-2070736857).