### PR TITLE
Test on ARM macOS runners

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ["3.8", "3.12"]
         include:
           - os: macos-latest
-            python-version: "3.11"
+            python-version: "3.12"
           - os: windows-latest
             python-version: "3.10"
     steps:

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -20,10 +20,10 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.8", "3.12"]
         include:
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.11"
           - os: windows-latest
             python-version: "3.10"
     steps:


### PR DESCRIPTION
~~This is due to python 3.8 no longer being available on the macos-latest CI runner.~~

This ~also~ allows us to now perform CI on ARM chips on macOS.

This also restores the ubuntu minimum version to 3.8 so that we test on 3.8 somewhere. https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/issues/515#issuecomment-2073378582

~~We might see intermittent CI failures again until #556 is merged (expected to be very soon).~~