### PR TITLE
Switch to `macos-13` runner so it is an Intel chip

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.12"]
         include:
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.8"
           - os: windows-latest
             python-version: "3.10"


### PR DESCRIPTION
cplex, which is required by cutqc, is not available on ARM