### PR TITLE
Revert "Temporarily disable worktrees in docs and lint workflows (#559)"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,11 +28,6 @@ jobs:
           pip install tox
           sudo apt-get update
           sudo apt-get install -y pandoc
-      - name: Temporary workaround for GitVersion
-        shell: bash
-        run: |
-          git config --unset-all extensions.worktreeconfig
-          # See https://github.com/GitTools/actions/issues/1115
       - name: Tell reno to name the upcoming release after the branch we are on
         shell: bash
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,11 +26,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Temporary workaround for GitVersion
-        shell: bash
-        run: |
-          git config --unset-all extensions.worktreeconfig
-          # See https://github.com/GitTools/actions/issues/1115
       - name: Run styles check
         shell: bash
         run: |


### PR DESCRIPTION
This reverts commit 0d9cb60e7316f9a1ab6d92a11d6c2c8b6134351c (#559).

I believe the temporary workaround is no longer needed.