### PR TITLE
Force at least one classical bit in `qpd_measurements` register

### DIFF
--- a/circuit_knitting/cutting/qpd/decompose.py
+++ b/circuit_knitting/cutting/qpd/decompose.py
@@ -145,10 +145,10 @@ def _decompose_qpd_measurements(
         if instruction.operation.name.lower() == "qpd_measure"
     ]
 
-    # Create a classical register for the qpd measurement results.  This is
-    # partly for convenience, partly to work around
-    # https://github.com/Qiskit/qiskit-aer/issues/1660.
-    reg = ClassicalRegister(len(qpd_measure_ids), name="qpd_measurements")
+    # Create a classical register for the qpd measurement results.
+    # We force at least one classical bit as a workaround to
+    # https://github.com/openqasm/qe-qasm/issues/37.
+    reg = ClassicalRegister(max(1, len(qpd_measure_ids)), name="qpd_measurements")
     circuit.add_register(reg)
 
     # Place the measurement instructions

--- a/releasenotes/notes/nonzero-register-size-e112e34417ff79b9.yaml
+++ b/releasenotes/notes/nonzero-register-size-e112e34417ff79b9.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Added a workaround so that the classical registers in the
+    generated circuits will always contain at least one bit.  This is
+    currently necessary for the experiments to be able to reach IBM
+    Quantum's hardware backends due to an `openqasm parser issue
+    <https://github.com/openqasm/qe-qasm/issues/37>`__.

--- a/test/cutting/qpd/test_qpd.py
+++ b/test/cutting/qpd/test_qpd.py
@@ -148,7 +148,7 @@ class TestQPDFunctions(unittest.TestCase):
         with self.subTest("Empty circuit"):
             circ = QuantumCircuit()
             new_circ = decompose_qpd_instructions(QuantumCircuit(), [])
-            circ.add_register(ClassicalRegister(0, name="qpd_measurements"))
+            circ.add_register(ClassicalRegister(1, name="qpd_measurements"))
             self.assertEqual(circ, new_circ)
         with self.subTest("No QPD circuit"):
             circ = QuantumCircuit(2, 1)
@@ -156,7 +156,7 @@ class TestQPDFunctions(unittest.TestCase):
             circ.cx(0, 1)
             circ.measure(1, 0)
             new_circ = decompose_qpd_instructions(circ, [])
-            circ.add_register(ClassicalRegister(0, name="qpd_measurements"))
+            circ.add_register(ClassicalRegister(1, name="qpd_measurements"))
             self.assertEqual(circ, new_circ)
         with self.subTest("Single QPD gate"):
             circ = QuantumCircuit(2)
@@ -165,7 +165,7 @@ class TestQPDFunctions(unittest.TestCase):
             qpd_gate = TwoQubitQPDGate(qpd_basis)
             circ.data.append(CircuitInstruction(qpd_gate, qubits=[0, 1]))
             decomp_circ = decompose_qpd_instructions(circ, [[0]], map_ids=[0])
-            circ_compare.add_register(ClassicalRegister(0, name="qpd_measurements"))
+            circ_compare.add_register(ClassicalRegister(1, name="qpd_measurements"))
             self.assertEqual(decomp_circ, circ_compare)
         with self.subTest("Incorrect map index size"):
             with pytest.raises(ValueError) as e_info:


### PR DESCRIPTION
Fixes #564 

This is a potential workaround to https://github.com/openqasm/qe-qasm/issues/37