### PR TITLE
Early terminate from loops when generating cutting experiments

### DIFF
--- a/circuit_knitting/cutting/cutting_experiments.py
+++ b/circuit_knitting/cutting/cutting_experiments.py
@@ -409,7 +409,7 @@ def _remove_resets_in_zero_state(
         circuit = circuit.copy()
 
     # Keep up with which qubits have at least one non-reset instruction
-    active_qubits = set()
+    active_qubits: set[int] = set()
     remove_ids = []
     for i, inst in enumerate(circuit.data):
         qargs = [circuit.find_bit(q).index for q in inst.qubits]
@@ -419,6 +419,9 @@ def _remove_resets_in_zero_state(
         else:
             for q in qargs:
                 active_qubits.add(q)
+            # Early terminate once all qubits have become active
+            if len(active_qubits) == circuit.num_qubits:
+                break
 
     for i in sorted(remove_ids, reverse=True):
         del circuit.data[i]
@@ -446,6 +449,9 @@ def _remove_final_resets(
         else:
             for q in qargs:
                 qubit_ended.discard(q)
+            # Early terminate once all qubits have been touched
+            if not qubit_ended:
+                break
 
     for i in sorted(remove_ids, reverse=True):
         del circuit.data[i]

--- a/test/cutting/test_cutting_experiments.py
+++ b/test/cutting/test_cutting_experiments.py
@@ -275,7 +275,7 @@ class TestCuttingExperiments(unittest.TestCase):
         _remove_final_resets(circuit)
         self.assertEqual(expected, circuit)
 
-    def test_optimize_single_reset(self):
+    def test_optimize_single_final_reset(self):
         """Remove a single final reset
         qr0:--[H]--|0>--   ==>    qr0:--[H]--
         """
@@ -286,6 +286,27 @@ class TestCuttingExperiments(unittest.TestCase):
 
         expected = QuantumCircuit(qr)
         expected.h(0)
+
+        _remove_final_resets(circuit)
+
+        self.assertEqual(expected, circuit)
+
+    def test_optimize_single_final_reset_2(self):
+        """Remove a single final reset on two qubits
+        qr0:--[H]--|0>--   ==>    qr0:--[H]-------
+            --[X]--[S]--              --[X]--[S]--
+        """
+        qr = QuantumRegister(2, "qr")
+        circuit = QuantumCircuit(qr)
+        circuit.h(0)
+        circuit.x(1)
+        circuit.reset(0)
+        circuit.s(1)
+
+        expected = QuantumCircuit(qr)
+        expected.h(0)
+        expected.x(1)
+        expected.s(1)
 
         _remove_final_resets(circuit)
 


### PR DESCRIPTION
This is a follow-up to #556.