### PR TITLE
RFC: Use hatch-vcs to determine project's version from git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "circuit-knitting-toolbox"
-version = "0.7.1"
+dynamic = ["version"]
 description = "A software prototype for a circuit knitting toolbox which connects user applications with runtime primitives"
 readme = "README.md"
 license = {file = "LICENSE.txt"}
@@ -96,6 +96,8 @@ notebook-dependencies = [
 "Documentation" = "https://qiskit-extensions.github.io/circuit-knitting-toolbox/"
 "Repository" = "https://github.com/Qiskit-Extensions/circuit-knitting-toolbox"
 
+[tool.hatch.version]
+source = "vcs"
 [tool.hatch.build.targets.wheel]
 only-include = [
     "circuit_knitting",


### PR DESCRIPTION
This uses [hatch-vcs](https://github.com/ofek/hatch-vcs) to set the version automatically based on the most recent git tag, instead of having it specified and bumped manually in `pyproject.toml`.  Two benefits I can think of

- One fewer step (line to update) when we do a release
- Each git commit will be given a unique version string.  For instance, with this PR, _only_ when the version is equivalent to the `0.7.1` tag will it be returned as `0.7.1` precisely.  Otherwise, it will be a dev version string including the hash of the commit in use (such as the following repl demonstration for the current commit in this PR).  This will give us much better version information if we want to know precisely what (possibly development) version of ckt a user has installed.
  ```
  >>> import circuit_knitting
  >>> circuit_knitting.__version__
  '0.7.2.dev2+g4e93e75'
  ```

Downside:
- adds a build dependency on hatch-vcs