### PR TITLE
Update authors in `CITATION.bib`

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,5 +1,5 @@
 @misc{circuit-knitting-toolbox,
-  author = {Luciano Bello and Agata M. Bra\'{n}czyk and Sergey Bravyi and Almudena {Carrera Vazquez} and Andrew Eddins and Daniel J. Egger and Bryce Fuller and Julien Gacon and James R. Garrison and Jennifer R. Glick and Tanvi P. Gujarati and Ikko Hamamura and Areeq I. Hasan and Takashi Imamichi and Caleb Johnson and Ieva Liepuoniute and Owen Lockwood and Mario Motta and C. D. Pemmaraju and Pedro Rivero and Max Rossmannek and Travis L. Scholten and Seetharami Seelam and Iskandar Sitdikov and Dharmashankar Subramanian and Wei Tang and Stefan Woerner},
+  author = {Agata M. Bra\'{n}czyk and Almudena {Carrera Vazquez} and Daniel J. Egger and Bryce Fuller and Julien Gacon and James R. Garrison and Jennifer R. Glick and Areeq I. Hasan and Takashi Imamichi and Caleb Johnson and Saasha Joshi and Owen Lockwood and Edwin Pednault and C. D. Pemmaraju and Pedro Rivero and Max Rossmannek and Travis L. Scholten and Seetharami Seelam and Ibrahim Shehzad and Iskandar Sitdikov and Dharmashankar Subramanian and Wei Tang and Stefan Woerner},
   title = {{Circuit Knitting Toolbox}},
   howpublished = {\url{https://github.com/Qiskit-Extensions/circuit-knitting-toolbox}},
   year = {2023},

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,8 @@ If you use the Circuit Knitting Toolbox in your research, please cite it accordi
 .. literalinclude:: ../CITATION.bib
    :language: bibtex
 
+If you are using the entanglement forging tool in CKT version 0.5.0 or earlier, please use `an older version of the citation file <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/stable/0.5/CITATION.bib>`__ which includes the authors of that tool.
+
 Developer guide
 ---------------
 


### PR DESCRIPTION
I've removed the authors who contributed solely to forging and added a few authors who have contributed to circuit knitting.  I also updated the documentation to encourage users of forging to use an older version of the citation.

It's worth triple checking this to make sure there are no errors.

Closes #375.