### PR TITLE
Update `CITATION.bib` to remove entanglement forging authors

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,5 +1,23 @@
 @misc{circuit-knitting-toolbox,
-  author = {Agata M. Bra\'{n}czyk and Almudena {Carrera Vazquez} and Daniel J. Egger and Bryce Fuller and Julien Gacon and James R. Garrison and Jennifer R. Glick and Areeq I. Hasan and Takashi Imamichi and Caleb Johnson and Saasha Joshi and Owen Lockwood and Edwin Pednault and C. D. Pemmaraju and Pedro Rivero and Max Rossmannek and Travis L. Scholten and Seetharami Seelam and Ibrahim Shehzad and Iskandar Sitdikov and Dharmashankar Subramanian and Wei Tang and Stefan Woerner},
+  author = {
+    Agata M. Bra\'{n}czyk
+    and Almudena {Carrera Vazquez}
+    and Daniel J. Egger
+    and Bryce Fuller
+    and Julien Gacon
+    and James R. Garrison
+    and Jennifer R. Glick
+    and Caleb Johnson
+    and Saasha Joshi
+    and Edwin Pednault
+    and C. D. Pemmaraju
+    and Pedro Rivero
+    and Seetharami Seelam
+    and Ibrahim Shehzad
+    and Dharmashankar Subramanian
+    and Wei Tang
+    and Stefan Woerner
+  },
   title = {{Circuit Knitting Toolbox}},
   howpublished = {\url{https://github.com/Qiskit-Extensions/circuit-knitting-toolbox}},
   year = {2023},


### PR DESCRIPTION
This is a follow up to #580.  This removes six additional authors who only contributed to entanglement forging and have made no direct contributions to circuit cutting to the best of my knowledge.

I've also reformatted with one author per line.

A diff that ignores whitespace can be generated by running `git show --color-words` on this branch.