### PR TITLE
Tuple unpacking bug fix in cut finder.

### DIFF
--- a/circuit_knitting/cutting/cut_finding/cutting_actions.py
+++ b/circuit_knitting/cutting/cut_finding/cutting_actions.py
@@ -417,7 +417,7 @@ class ActionCutBothWires(DisjointSearchAction):
         new_state.bell_pairs.append((r2, rnew_2))
         new_state.gamma_UB *= 16
 
-        new_state.add_action(self, gate_spec, ((1, w1, rnew_1), (2, w2, rnew_2)))
+        new_state.add_action(self, gate_spec, (1, w1, rnew_1), (2, w2, rnew_2))
 
         return [new_state]
 

--- a/circuit_knitting/cutting/cut_finding/disjoint_subcircuits_state.py
+++ b/circuit_knitting/cutting/cut_finding/disjoint_subcircuits_state.py
@@ -37,7 +37,7 @@ class Action(NamedTuple):
 
     action: DisjointSearchAction
     gate_spec: GateSpec
-    args: list
+    args: list | tuple
 
 
 class GateCutLocation(NamedTuple):
@@ -430,12 +430,12 @@ class DisjointSubcircuitsState:
         self,
         action_obj: DisjointSearchAction,
         gate_spec: GateSpec,
-        args: tuple | None = None,
+        *args: tuple | None,
     ) -> None:
         """Append the specified action to the list of search-space actions that have been performed."""
         if action_obj.get_name() is not None:
             self.actions = cast(list, self.actions)
-            self.actions.append(Action(action_obj, gate_spec, [args]))
+            self.actions.append(Action(action_obj, gate_spec, args))
 
     def get_search_level(self) -> int:
         """Return the search level."""

--- a/test/cutting/cut_finding/test_best_first_search.py
+++ b/test/cutting/cut_finding/test_best_first_search.py
@@ -114,7 +114,7 @@ def test_best_first_search(test_circuit: SimpleGateList):
                 gate=CircuitElement(name="cx", params=[], qubits=[3, 4], gamma=3),
                 cut_constraints=None,
             ),
-            [((1, 3), (2, 4))],
+            (((1, 3), (2, 4)),),
         ),
         (
             GateSpec(
@@ -122,7 +122,7 @@ def test_best_first_search(test_circuit: SimpleGateList):
                 gate=CircuitElement(name="cx", params=[], qubits=[3, 5], gamma=3),
                 cut_constraints=None,
             ),
-            [((1, 3), (2, 5))],
+            (((1, 3), (2, 5)),),
         ),
         (
             GateSpec(
@@ -130,7 +130,7 @@ def test_best_first_search(test_circuit: SimpleGateList):
                 gate=CircuitElement(name="cx", params=[], qubits=[3, 6], gamma=3),
                 cut_constraints=None,
             ),
-            [((1, 3), (2, 6))],
+            (((1, 3), (2, 6)),),
         ),
     ]
 


### PR DESCRIPTION
There was a tuple unpacking error that arose when the`CutBothWires` action was invoked as part of the rest of the cut finding workflow. This bug was not noticed at first because the although existing tests called that line, its output was not used in any part of the rest of the workflow. This bug was noticed in the work leading up to #586  which will also add more comprehensive tests for the `CutBothWires` action. The goal of this PR is just to fix this bug and edit the corresponding tests and type hints accordingly.