### PR TITLE
Remove explicit dependency on ipykernel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,9 +77,6 @@ docs = [
     "sphinx-autodoc-typehints>=1.12.0",
     "sphinx-reredirects",
     "jupyter-sphinx>=0.3.2",
-    # The following line is needed until
-    # https://github.com/jupyter/jupyter-sphinx/pull/226 is resolved.
-    "ipykernel>=4.5.1",
     "nbsphinx>=0.8.8",
     "sphinx-copybutton>=0.5.0",
     "reno>=3.4.0",


### PR DESCRIPTION
This is no longer necessary now that a release has been made which includes https://github.com/jupyter/jupyter-sphinx/pull/226.

This PR reverts #345.