### PR TITLE
Fix coverage workflow and remove workflow dependency on coveragepy-lcov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,10 +34,10 @@ jobs:
         run: |
           tox -e coverage
       - name: Convert to lcov
-        run: coverage3 lcov -o coveralls.info
+        run: coverage3 lcov -o coveralls.lcov
       - name: Upload report to Coveralls
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coveralls.info
+          file: coveralls.lcov
           format: lcov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
-          pip install tox coveragepy-lcov 'coverage<7'
+          pip install tox coverage
       - name: Run coverage
         run: |
           tox -e coverage
       - name: Convert to lcov
-        run: coveragepy-lcov --output_file_path coveralls.info
+        run: coverage3 lcov -o coveralls.info
       - name: Upload report to Coveralls
         uses: coverallsapp/github-action@v2
         with:


### PR DESCRIPTION
It looks like we no longer even need to coveragepy-lcov tool: https://github.com/nedbat/coveragepy/issues/587#issuecomment-1019370754