### PR TITLE
Tutorials: Fix typo and split cell that retrieves results

### DIFF
--- a/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
+++ b/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
@@ -314,14 +314,14 @@
    "source": [
     "from qiskit_ibm_runtime import SamplerV2, Batch\n",
     "\n",
-    "# Set up a Qiskit Runtime Sampler primitive for each circuit partition\n",
-    "samplers = {label: SamplerV2(backend=backend) for label in subexperiments.keys()}\n",
+    "# Set up the Qiskit Runtime Sampler primitive\n",
+    "sampler = SamplerV2(backend=backend)\n",
     "\n",
     "# Submit each partition's subexperiments as a single batch\n",
     "with Batch(backend=backend):\n",
     "    jobs = {\n",
-    "        label: sampler.run(isa_subexperiments[label], shots=2**12)\n",
-    "        for label, sampler in samplers.items()\n",
+    "        label: sampler.run(subsystem_subexpts, shots=2**12)\n",
+    "        for label, subsystem_subexpts in isa_subexperiments.items()\n",
     "    }"
    ]
   },

--- a/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
+++ b/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
@@ -299,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "3bc1c07b-b286-4a5f-8b0a-67efd4a6309e",
+   "id": "2dbb8148-0482-4a66-8316-335125f8a2b3",
    "metadata": {},
    "outputs": [
     {
@@ -322,9 +322,17 @@
     "    jobs = {\n",
     "        label: sampler.run(isa_subexperiments[label], shots=2**12)\n",
     "        for label, sampler in samplers.items()\n",
-    "    }\n",
-    "\n",
-    "# Retrive results\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "64cef60b-5130-467e-8e01-7460d78560ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Retrieve results\n",
     "results = {label: job.result() for label, job in jobs.items()}"
    ]
   },

--- a/docs/circuit_cutting/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
+++ b/docs/circuit_cutting/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
@@ -312,8 +312,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "80dd2a66",
+   "execution_count": null,
+   "id": "16968c09-13f0-499b-91d0-91b58f1ce6eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,8 +326,16 @@
     "sampler = SamplerV2(backend=backend)\n",
     "\n",
     "# Submit the subexperiments\n",
-    "job = sampler.run(isa_subexperiments)\n",
-    "\n",
+    "job = sampler.run(isa_subexperiments)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a83922bc-0489-4ee5-a2b6-796103aae9bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Retrieve the results\n",
     "results = job.result()"
    ]

--- a/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
+++ b/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
@@ -393,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "49cfcf6f-7ac3-4c1e-9dc7-ea79f011d37c",
+   "id": "bdf3bd2f-e10a-4148-a7ad-f354492614cc",
    "metadata": {},
    "outputs": [
     {
@@ -416,18 +416,18 @@
     "    jobs = {\n",
     "        label: sampler.run(isa_subexperiments[label], shots=2**12)\n",
     "        for label, sampler in samplers.items()\n",
-    "    }\n",
-    "\n",
-    "# Retrive results\n",
-    "results = {label: job.result() for label, job in jobs.items()}"
+    "    }"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "03bf7ba4-14c7-46de-901a-855456372d7b",
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "abb436de-9662-4c47-92b1-659ee0334adc",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "To use the Qiskit Runtime Sampler, replace the code above with this commented block."
+    "# Retrieve results\n",
+    "results = {label: job.result() for label, job in jobs.items()}"
    ]
   },
   {

--- a/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
+++ b/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
@@ -408,14 +408,14 @@
    "source": [
     "from qiskit_ibm_runtime import SamplerV2, Batch\n",
     "\n",
-    "# Set up a Qiskit Runtime Sampler primitive for each circuit partition\n",
-    "samplers = {label: SamplerV2(backend=backend) for label in subexperiments.keys()}\n",
+    "# Set up the Qiskit Runtime Sampler primitive\n",
+    "sampler = SamplerV2(backend=backend)\n",
     "\n",
     "# Submit each partition's subexperiments as a single batch\n",
     "with Batch(backend=backend):\n",
     "    jobs = {\n",
-    "        label: sampler.run(isa_subexperiments[label], shots=2**12)\n",
-    "        for label, sampler in samplers.items()\n",
+    "        label: sampler.run(subsystem_subexpts, shots=2**12)\n",
+    "        for label, subsystem_subexpts in isa_subexperiments.items()\n",
     "    }"
    ]
   },


### PR DESCRIPTION
This fixes a typo and splits the cell so that the results are retrieved in their own cell.  This is nice because then the user will have a cell complete once all jobs are submitted and another complete when all results are available.  I also removed an outdated reference to the old "commented block."