### PR TITLE
Add note in INSTALL regarding Docker installation

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -100,6 +100,11 @@ build a Docker image, as well as a
 `compose.yaml <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/main/compose.yaml>`__ file, which allows one
 to use the Docker image with just a few simple commands.
 
+.. note::
+
+   Running these commands will copy everything in the repository into the container, so it may be preferable to
+   clear extraneous files from your local repository before initializing the container.
+
 .. code:: sh
 
     git clone git@github.com:Qiskit-Extensions/circuit-knitting-toolbox.git


### PR DESCRIPTION
This note is at least useful for developers who will commonly have large `.tox` directories in their local repository, along with other caches which speed up local CI.

This could also be useful for someone running a local install and using the repository as a dumping grounds for results.