### PR TITLE
Remove `basepython` restriction in `lint` and `coverage` environments

### DIFF
--- a/circuit_knitting/utils/bitwise.py
+++ b/circuit_knitting/utils/bitwise.py
@@ -25,7 +25,7 @@ if hasattr(0, "bit_count"):
     def bit_count(x: int, /):  # pragma: no cover
         """Count number of set bits."""
         # New in Python 3.10
-        return x.bit_count()
+        return x.bit_count()  # type: ignore[attr-defined]
 
 else:
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ commands =
   black circuit_knitting/ docs/ test/ tools/
 
 [testenv:lint]
-basepython = python3.10
 extras =
   lint
 commands =
@@ -41,7 +40,6 @@ commands =
   pytest --nbmake --nbmake-timeout=300 {posargs} docs/ --ignore=docs/_build
 
 [testenv:coverage]
-basepython = python3.10
 deps =
   coverage>=5.5
 extras =


### PR DESCRIPTION
This restriction was previously necessary, but it no longer appears to be, as far as I can tell.

Getting rid of the restriction will make these environments work on systems where `python3.10` is not installed.