### PR TITLE
Bump qiskit-ibm-runtime version and use `mode=batch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   [![Release](https://img.shields.io/pypi/v/circuit-knitting-toolbox.svg?label=Release)](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/releases)
   ![Platform](https://img.shields.io/badge/%F0%9F%92%BB%20Platform-Linux%20%7C%20macOS%20%7C%20Windows-informational)
   [![Python](https://img.shields.io/pypi/pyversions/circuit-knitting-toolbox?label=Python&logo=python)](https://www.python.org/)
-  [![Qiskit](https://img.shields.io/badge/Qiskit%20-%20%3E%3D1.0%20-%20%236133BD?logo=Qiskit)](https://github.com/Qiskit/qiskit)
+  [![Qiskit](https://img.shields.io/badge/Qiskit%20-%20%3E%3D1.1%20-%20%236133BD?logo=Qiskit)](https://github.com/Qiskit/qiskit)
 <br />
   [![Docs (stable)](https://img.shields.io/badge/%F0%9F%93%84%20Docs-stable-blue.svg)](https://qiskit-extensions.github.io/circuit-knitting-toolbox/)
   [![DOI](https://zenodo.org/badge/543181258.svg)](https://zenodo.org/badge/latestdoi/543181258)

--- a/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
+++ b/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
@@ -317,7 +317,7 @@
     "# Submit each partition's subexperiments to the Qiskit Runtime Sampler\n",
     "# primitive, in a single batch so that the jobs will run back-to-back.\n",
     "with Batch(backend=backend) as batch:\n",
-    "    sampler = SamplerV2(session=batch)\n",
+    "    sampler = SamplerV2(mode=batch)\n",
     "    jobs = {\n",
     "        label: sampler.run(subsystem_subexpts, shots=2**12)\n",
     "        for label, subsystem_subexpts in isa_subexperiments.items()\n",

--- a/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
+++ b/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
@@ -411,7 +411,7 @@
     "# Submit each partition's subexperiments to the Qiskit Runtime Sampler\n",
     "# primitive, in a single batch so that the jobs will run back-to-back.\n",
     "with Batch(backend=backend) as batch:\n",
-    "    sampler = SamplerV2(session=batch)\n",
+    "    sampler = SamplerV2(mode=batch)\n",
     "    jobs = {\n",
     "        label: sampler.run(subsystem_subexpts, shots=2**12)\n",
     "        for label, subsystem_subexpts in isa_subexperiments.items()\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
     "scipy>=1.5.2",
     "rustworkx>=0.14.0",
     "qiskit-aer>=0.14.0.1",
-    "qiskit>=1.0.0, <2.0",
-    "qiskit-ibm-runtime>=0.23.0",
+    "qiskit>=1.1.0, <2.0",
+    "qiskit-ibm-runtime>=0.24.0",
 ]
 
 [project.optional-dependencies]

--- a/releasenotes/notes/bump-dependency-versions-26e93b55695c3034.yaml
+++ b/releasenotes/notes/bump-dependency-versions-26e93b55695c3034.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    CKT now requires updated versions of some dependencies: ``qiskit``
+    1.1 or later, and ``qiskit-ibm-runtime`` 0.24.0 or later.


### PR DESCRIPTION
This is necessary to prevent a `DeprecationWarning` under qiskit-ibm-runtime 0.24, which is currently visible in the [first](https://qiskit-extensions.github.io/circuit-knitting-toolbox/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.html) and third tutorials.  The warning is a result of the merging of https://github.com/Qiskit/qiskit-ibm-runtime/pull/1584.

qiskit-ibm-runtime 0.24 depends on qiskit>=1.1, so I had to bump the qiskit version as well.

Technically, this version bump is only required by the notebooks, not the actual CKT library, but the "minimum version tests" aren't equipped to deal with situations where the notebooks have a different minimum version than the CKT library.