### PR TITLE
Bump qiskit-ibm-runtime version and use `mode=batch` (backport #623)

### DIFF
--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -41,4 +41,4 @@ jobs:
         run: |
           pver=${{ matrix.python-version }}
           tox -epy${pver/./} -- --run-slow
-          tox -epy${pver/./}-notebook
+          #tox -epy${pver/./}-notebook

--- a/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
+++ b/docs/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
@@ -317,7 +317,7 @@
     "# Submit each partition's subexperiments to the Qiskit Runtime Sampler\n",
     "# primitive, in a single batch so that the jobs will run back-to-back.\n",
     "with Batch(backend=backend) as batch:\n",
-    "    sampler = SamplerV2(session=batch)\n",
+    "    sampler = SamplerV2(mode=batch)\n",
     "    jobs = {\n",
     "        label: sampler.run(subsystem_subexpts, shots=2**12)\n",
     "        for label, subsystem_subexpts in isa_subexperiments.items()\n",

--- a/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
+++ b/docs/circuit_cutting/tutorials/03_wire_cutting_via_move_instruction.ipynb
@@ -411,7 +411,7 @@
     "# Submit each partition's subexperiments to the Qiskit Runtime Sampler\n",
     "# primitive, in a single batch so that the jobs will run back-to-back.\n",
     "with Batch(backend=backend) as batch:\n",
-    "    sampler = SamplerV2(session=batch)\n",
+    "    sampler = SamplerV2(mode=batch)\n",
     "    jobs = {\n",
     "        label: sampler.run(subsystem_subexpts, shots=2**12)\n",
     "        for label, subsystem_subexpts in isa_subexperiments.items()\n",


### PR DESCRIPTION
This is a stable backport of #623.

This change is necessary to prevent a `DeprecationWarning` under qiskit-ibm-runtime 0.24, which is currently visible in the [first](https://qiskit-extensions.github.io/circuit-knitting-toolbox/circuit_cutting/tutorials/01_gate_cutting_to_reduce_circuit_width.html) and third tutorials and is due to the merging of https://github.com/Qiskit/qiskit-ibm-runtime/pull/1584.

This means that the notebooks now depend on qiskit-ibm-runtime 0.24, which depends on qiskit>=1.1.

The "minimum version tests" aren't equipped to deal with situations where the notebooks have a different minimum version than the library.  For this reason I've disabled the "minimum version tests" on the current stable branch going forward for the notebooks only. I don't want to bump the minimum version of any library on the stable branch, but I _do_ want to update our code examples to the latest version of qiskit-ibm-runtime.