### PR TITLE
Pin numpy<2 on stable branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">=3.8"
 
 dependencies = [
-    "numpy>=1.23.0",
+    "numpy>=1.23.0, <2",
     "scipy>=1.5.2",
     "rustworkx>=0.14.0",
     "qiskit-aer>=0.14.0.1",


### PR DESCRIPTION
From the looks of the CI failure, DOCplex is incompatible with numpy 2.0.  So, as a way to make the CutQC code continue to work, I am pinning to `numpy <2` on the `stable/0.7` branch.  (CutQC has already been removed from `main`, in #605.)