### PR TITLE
Pass `backend` as positional argument to `SamplerV2` for job mode

### DIFF
--- a/docs/circuit_cutting/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
+++ b/docs/circuit_cutting/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
@@ -323,7 +323,7 @@
     "isa_subexperiments = pass_manager.run(subexperiments)\n",
     "\n",
     "# Set up the Qiskit Runtime Sampler primitive.  For a fake backend, this will use a local simulator.\n",
-    "sampler = SamplerV2(backend=backend)\n",
+    "sampler = SamplerV2(backend)\n",
     "\n",
     "# Submit the subexperiments\n",
     "job = sampler.run(isa_subexperiments)"

--- a/test/cutting/test_cutting_workflows.py
+++ b/test/cutting/test_cutting_workflows.py
@@ -204,9 +204,7 @@ def test_reconstruction_with_samplerv2():
     )
 
     # Use SamplerV2 in local mode with AerSimulator
-    samplers = {
-        label: SamplerV2(AerSimulator()) for label in subexperiments.keys()
-    }
+    samplers = {label: SamplerV2(AerSimulator()) for label in subexperiments.keys()}
     results = {
         label: sampler.run(subexperiments[label], shots=128).result()
         for label, sampler in samplers.items()

--- a/test/cutting/test_cutting_workflows.py
+++ b/test/cutting/test_cutting_workflows.py
@@ -205,7 +205,7 @@ def test_reconstruction_with_samplerv2():
 
     # Use SamplerV2 in local mode with AerSimulator
     samplers = {
-        label: SamplerV2(backend=AerSimulator()) for label in subexperiments.keys()
+        label: SamplerV2(AerSimulator()) for label in subexperiments.keys()
     }
     results = {
         label: sampler.run(subexperiments[label], shots=128).result()


### PR DESCRIPTION
This fixes a deprecation warning.

Fixes #632.