### PR TITLE
Fix deprecation of iterable `CircuitInstruction` under Qiskit 1.2

### DIFF
--- a/circuit_knitting/cutting/wire_cutting_transforms.py
+++ b/circuit_knitting/cutting/wire_cutting_transforms.py
@@ -76,7 +76,7 @@ def _transform_cut_wires(
             mapping[gate_index[0]] += 1
         else:
             new_circuit.compose(
-                other=instructions[0],
+                other=instructions.operation,
                 qubits=[mapping[index] for index in gate_index],
                 inplace=True,
             )

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -37,7 +37,7 @@ def prepare_hwea():
 
     # Exchange CNOTs with gates we support
     for i, gate in enumerate(circuit.data):
-        if len(gate[1]) == 2:
+        if len(gate.qubits) == 2:
             q1 = circuit.find_bit(gate.qubits[0])[0]
             q2 = circuit.find_bit(gate.qubits[1])[0]
             circuit.data[i] = CircuitInstruction(RZZGate(np.pi / 4), qubits=[q1, q2])


### PR DESCRIPTION
```
test/cutting/test_wire_cutting_transforms.py: 88 warnings
test/cutting/test_cutting_workflows.py: 4 warnings
  /home/runner/work/circuit-knitting-toolbox/circuit-knitting-toolbox/circuit_knitting/cutting/wire_cutting_transforms.py:79: DeprecationWarning: Treating CircuitInstruction as an iterable is deprecated legacy behavior since Qiskit 1.2, and will be removed in Qiskit 2.0. Instead, use the `operation`, `qubits` and `clbits` named attributes.
    other=instructions[0],

test/utils/test_transforms.py: 76 warnings
  /home/runner/work/circuit-knitting-toolbox/circuit-knitting-toolbox/test/utils/test_transforms.py:40: DeprecationWarning: Treating CircuitInstruction as an iterable is deprecated legacy behavior since Qiskit 1.2, and will be removed in Qiskit 2.0. Instead, use the `operation`, `qubits` and `clbits` named attributes.
    if len(gate[1]) == 2:
```