### PR TITLE
Prepare 0.7.3 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "circuit-knitting-toolbox"
-version = "0.7.2"
+version = "0.7.3"
 description = "A software prototype for a circuit knitting toolbox which connects user applications with runtime primitives"
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/releasenotes/notes/0.7/prepare-0.7.3-86eeb02864cf60b0.yaml
+++ b/releasenotes/notes/0.7/prepare-0.7.3-86eeb02864cf60b0.yaml
@@ -1,0 +1,12 @@
+---
+prelude: |
+  The 0.7.3 release fixes the circuit cutting code to be compatible
+  with the forthcoming Qiskit 1.2 release.  It also pins numpy to
+  version 1.X, as DOCplex (which is used by the legacy CutQC
+  implementation) is incompatible with numpy 2.0.
+fixes:
+  - |
+    The circuit cutting module now uses a stringified UUID instead of
+    a ``UUID`` object when it needs to generate a unique label for
+    circuit barriers during processing, as the forthcoming Qiskit 1.2
+    release requires that labels always be a string.


### PR DESCRIPTION
As the release note explains, we must make a release before August 15 (when Qiskit 1.2 [is due to be released](https://github.com/Qiskit/qiskit/milestone/50)).  Also, a fresh install of CutQC is broken unless a user knows to pin `numpy<2` themself until we cut this release, so we might as well make a patchlevel release sooner rather than later.

Remaining action items (checklist for patchlevel release):
- [ ] Test all tutorial notebooks on a hardware backend
- [x] Update version [sub]string in all files where it appears in the repository
  - [x] `pyproject.toml`
- [x] move release notes to `0.7` directory
- [x] merge everything except this PR on the [0.7.3 milestone](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/milestone/17)
- [x] double check that all recent  PRs with stable backport potential have been backported.
- [x] build docs locally; proofread the release notes
- [ ] merge this PR
- [ ] tag the release
   1. `git checkout stable/0.7`
   2. `git pull`
   3. `git show` (verify it's the commit we want to tag)
   4. `git tag -a 0.7.3 -m "Circuit Knitting Toolbox 0.7.3"`
   5. `git show` (double/triple check the tag is on the correct branch)
   6. `git push origin 0.7.3`
- [ ] Wait for CI to finish. The release should then be available on GitHub and pypi.
- [ ] get docs to deploy (should happen automatically at this point after CI runs both on `stable/0.7` and then on the `gh-pages` branch)
- [ ] move remaining `0.7.3` milestone items to `0.7.4` milestone and close the `0.7.3` milestone

Previous patchlevel release PR: #590