### PR TITLE
Pin `ruff==0.5.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ nbtest = [
 style = [
     "autoflake==2.3.1",
     "black[jupyter]~=24.1",
-    "ruff>=0.0.246",
+    "ruff==0.5.1",
     "nbqa>=1.6.0",
 ]
 lint = [


### PR DESCRIPTION
We pin most of our linters, but we have gotten away so far without pinning ruff.  However, today CI is broken because the ruff 0.5.2 (patchlevel) release seems to have added a rule.  (Or maybe it fixed a rule that was broken before.  Either way, it broke us.)

From here forward, let's pin ruff, too, and dependabot can propose updating the version from time to time, just as it does with the other linters.