### PR TITLE
Use Aer's SamplerV2 instead of SamplerV1

### DIFF
--- a/test/cutting/test_cutting_roundtrip.py
+++ b/test/cutting/test_cutting_roundtrip.py
@@ -42,7 +42,7 @@ from qiskit.circuit.library.standard_gates import (
 )
 from qiskit.quantum_info import PauliList, random_unitary
 from qiskit.primitives import Estimator
-from qiskit_aer.primitives import Sampler
+from qiskit_aer.primitives import Sampler, SamplerV2
 
 from circuit_knitting.utils.simulation import ExactSampler
 from circuit_knitting.cutting import (
@@ -172,7 +172,8 @@ def test_cutting_exact_reconstruction(example_circuit):
 
 
 @pytest.mark.parametrize(
-    "sampler,is_exact_sampler", [(Sampler(), False), (ExactSampler(), True)]
+    "sampler,is_exact_sampler",
+    [(Sampler(), False), (SamplerV2(), False), (ExactSampler(), True)],
 )
 def test_sampler_with_identity_subobservable(sampler, is_exact_sampler):
     """This test ensures that the sampler works for a subcircuit with no observable measurements.

--- a/test/cutting/test_cutting_roundtrip.py
+++ b/test/cutting/test_cutting_roundtrip.py
@@ -42,7 +42,9 @@ from qiskit.circuit.library.standard_gates import (
 )
 from qiskit.quantum_info import PauliList, random_unitary
 from qiskit.primitives import Estimator
-from qiskit_aer.primitives import Sampler, SamplerV2
+from qiskit_ibm_runtime import SamplerV2
+from qiskit_aer import AerSimulator
+from qiskit_aer.primitives import Sampler
 
 from circuit_knitting.utils.simulation import ExactSampler
 from circuit_knitting.cutting import (
@@ -173,7 +175,7 @@ def test_cutting_exact_reconstruction(example_circuit):
 
 @pytest.mark.parametrize(
     "sampler,is_exact_sampler",
-    [(Sampler(), False), (SamplerV2(), False), (ExactSampler(), True)],
+    [(Sampler(), False), (SamplerV2(AerSimulator()), False), (ExactSampler(), True)],
 )
 def test_sampler_with_identity_subobservable(sampler, is_exact_sampler):
     """This test ensures that the sampler works for a subcircuit with no observable measurements.

--- a/test/cutting/test_cutting_workflows.py
+++ b/test/cutting/test_cutting_workflows.py
@@ -21,7 +21,6 @@ from qiskit.quantum_info import PauliList
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit_ibm_runtime import SamplerV2
-from qiskit_aer.primitives import SamplerV2 as AerSamplerV2
 from qiskit_aer import AerSimulator
 
 from circuit_knitting.cutting.qpd.instructions import SingleQubitQPDGate
@@ -89,11 +88,11 @@ def test_exotic_labels(label1, label2):
     assert subexperiments.keys() == subcircuits.keys()
 
     samplers = {
-        label1: AerSamplerV2(run_options={"shots": 10}),
-        label2: AerSamplerV2(run_options={"shots": 10}),
+        label1: SamplerV2(AerSimulator()),
+        label2: SamplerV2(AerSimulator()),
     }
     results = {
-        label: sampler.run(subexperiments[label]).result()
+        label: sampler.run(subexperiments[label], shots=10).result()
         for label, sampler in samplers.items()
     }
 

--- a/test/cutting/test_cutting_workflows.py
+++ b/test/cutting/test_cutting_workflows.py
@@ -21,7 +21,7 @@ from qiskit.quantum_info import PauliList
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit_ibm_runtime import SamplerV2
-from qiskit_aer.primitives import Sampler
+from qiskit_aer.primitives import SamplerV2 as AerSamplerV2
 from qiskit_aer import AerSimulator
 
 from circuit_knitting.cutting.qpd.instructions import SingleQubitQPDGate
@@ -89,8 +89,8 @@ def test_exotic_labels(label1, label2):
     assert subexperiments.keys() == subcircuits.keys()
 
     samplers = {
-        label1: Sampler(run_options={"shots": 10}),
-        label2: Sampler(run_options={"shots": 10}),
+        label1: AerSamplerV2(run_options={"shots": 10}),
+        label2: AerSamplerV2(run_options={"shots": 10}),
     }
     results = {
         label: sampler.run(subexperiments[label]).result()


### PR DESCRIPTION
Addresses part of #506.

#### Remaining action items

- [x] get it to work
- [ ] possibly also update an EstimatorV1 use in the roundtrip tests.