### PR TITLE
Make project's relationship with Qiskit consistent in the copyright headers

### DIFF
--- a/circuit_knitting/cutting/instructions/cut_wire.py
+++ b/circuit_knitting/cutting/instructions/cut_wire.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/circuit_knitting/cutting/instructions/move.py
+++ b/circuit_knitting/cutting/instructions/move.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/circuit_knitting/cutting/qpd/instructions/qpd_gate.py
+++ b/circuit_knitting/cutting/qpd/instructions/qpd_gate.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/circuit_knitting/cutting/qpd/instructions/qpd_measure.py
+++ b/circuit_knitting/cutting/qpd/instructions/qpd_measure.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/circuit_knitting/cutting/wire_cutting_transforms.py
+++ b/circuit_knitting/cutting/wire_cutting_transforms.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2022.
 #

--- a/test/cutting/test_wire_cutting_transforms.py
+++ b/test/cutting/test_wire_cutting_transforms.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #


### PR DESCRIPTION
Most CKT copyright headers say "This code is a Qiskit project." ... but a few stragglers say "This code is part of Qiskit."  This PR updates those stragglers.