### PR TITLE
Fix CI workflows to work with development versions of Python

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -43,6 +43,6 @@ jobs:
       - name: Test using tox environment
         shell: bash
         run: |
-          pver=${{ matrix.python-version }}
-          tox -epy${pver/./} -- --run-slow
-          tox -epy${pver/./}-notebook
+          toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
+          tox -epy${toxpyversion} -- --run-slow
+          tox -epy${toxpyversion}-notebook

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Test using tox environment
         shell: bash
         run: |
-          pver=${{ matrix.python-version }}
-          tox -epy${pver/./} -- --run-slow
-          tox -epy${pver/./}-notebook
+          toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
+          tox -epy${toxpyversion} -- --run-slow
+          tox -epy${toxpyversion}-notebook

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Test using tox environment
         shell: bash
         run: |
-          pver=${{ matrix.python-version }}
-          tox -epy${pver/./} -- --run-slow
-          tox -epy${pver/./}-notebook
+          toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
+          tox -epy${toxpyversion} -- --run-slow
+          tox -epy${toxpyversion}-notebook


### PR DESCRIPTION
This started off as part of #648, but it is conceptually an independent change, so I am splitting it off into its own commit.