### PR TITLE
Use `BaseSamplerV1` with explicit version

### DIFF
--- a/circuit_knitting/utils/simulation.py
+++ b/circuit_knitting/utils/simulation.py
@@ -29,7 +29,7 @@ from typing import Any
 import numpy as np
 from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import Statevector, Operator
-from qiskit.primitives.base import BaseSampler, SamplerResult
+from qiskit.primitives.base import BaseSamplerV1, SamplerResult
 from qiskit.primitives.primitive_job import PrimitiveJob
 from qiskit.result import QuasiDistribution
 
@@ -128,7 +128,7 @@ def simulate_statevector_outcomes(qc: QuantumCircuit, /) -> dict[int, float]:
     return {outcome: sum(prob for prob, _ in svs) for outcome, svs in current.items()}
 
 
-class ExactSampler(BaseSampler):
+class ExactSampler(BaseSamplerV1):
     """Sampler which returns exact probabilities for each possible outcome.
 
     This sampler supports:


### PR DESCRIPTION
This change is motivated by the following warning under the Qiskit 1.2 rc:

> DeprecationWarning: The class ``qiskit.primitives.base.base_sampler.BaseSampler`` is deprecated as of qiskit 1.2. It will be removed no earlier than 3 months after the release date. The `BaseSampler` class is a type alias for the `BaseSamplerV1` interface that has been deprecated in favor of explicitly versioned interface classes. It is recommended to migrate all implementations to use `BaseSamplerV2`. However, for implementations incompatible with `BaseSamplerV2`, `BaseSampler` can be replaced with the explicitly versioned `BaseSamplerV1` class.

Related to #551 and #506.