### PR TITLE
Pin qiskit-ibm-runtime when running notebooks

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -45,4 +45,4 @@ jobs:
         run: |
           pver=${{ matrix.python-version }}
           tox -epy${pver/./} -- --run-slow
-          tox -epy${pver/./}-notebook
+          tox -epy${pver/./}-notebook -- --ignore=docs/circuit_cutting/cutqc/tutorials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ docs = [
 ]
 notebook-dependencies = [
     "circuit-knitting-toolbox[cplex]",
+    "qiskit-ibm-runtime>=0.23.0, <0.28",
     "matplotlib",
     "ipywidgets",
     "pylatexenc",


### PR DESCRIPTION
PrimitivesV1 was dropped from qiskit-ibm-runtime 0.28, but we need them to run the cutqc tutorials.

NOTE: this is a PR to the `stable/0.7` branch only to fix the CI failure in #658.