### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,22 +26,22 @@ jobs:
     name: pypi
     runs-on: ubuntu-latest
     needs: github
+    environment:
+      name: pypi
+      url: https://pypi.org/p/qiskit-addon-cutting
+    permissions:
+      id-token: write
     steps:
       - name: Checkout tag
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
-      - name: Install hatch
+      - name: Install `build` tool
         run: |
           python -m pip install --upgrade pip
-          pip install hatch
-      - name: Build using hatch
+          pip install build
+      - name: Build distribution
         run: |
-          hatch build
-      - name: Publish release
-        env:
-          HATCH_INDEX_REPO: https://upload.pypi.org/legacy/
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          hatch publish
+          python -m build
+      - name: Publish release to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This updates `release.yml` to use pypi trusted publishers in an environment, largely following [this excellent guide](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).  A very similar process has been tested [in extremal-python-dependencies](https://github.com/IBM/extremal-python-dependencies/blob/main/.github/workflows/release.yml).  Note that this also has the advantage of meaning that we can change build system away from hatchling (not that we'd want to, at this point) without having to test the publishing mechanism.