### PR TITLE
Remove "prototype" handling from `citation.yml` workflow

### DIFF
--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -35,7 +35,7 @@ jobs:
           if [ -f "CITATION.bib" ]; then
           arr=(${GITHUB_REPOSITORY//\// })
           export REPO=${arr[1]}
-          cat <<- EOF > preview.tex
+          cat <<- EOF > citation-preview.tex
           \documentclass[preprint,aps,physrev,notitlepage]{revtex4-2}
           \usepackage{hyperref}
           \begin{document}
@@ -47,22 +47,22 @@ jobs:
           \bibliography{CITATION}
           \end{document}
           EOF
-          pdflatex preview
+          pdflatex citation-preview
           fi
       - name: Run BibTeX
         run: |
           if [ -f "CITATION.bib" ]; then
-          bibtex preview
+          bibtex citation-preview
           fi
       - name: Re-run LaTeX
         run: |
           if [ -f "CITATION.bib" ]; then
-          pdflatex preview
-          pdflatex preview
+          pdflatex citation-preview
+          pdflatex citation-preview
           fi
       - name: Upload PDF
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: preview.pdf
-          path: preview.pdf
+          name: citation-preview.pdf
+          path: citation-preview.pdf

--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -34,17 +34,16 @@ jobs:
         run: |
           if [ -f "CITATION.bib" ]; then
           arr=(${GITHUB_REPOSITORY//\// })
-          REPO=${arr[1]}
-          export PROTOTYPE=${REPO#"prototype-"}
+          export REPO=${arr[1]}
           cat <<- EOF > preview.tex
           \documentclass[preprint,aps,physrev,notitlepage]{revtex4-2}
           \usepackage{hyperref}
           \begin{document}
-          \title{\texttt{$PROTOTYPE} BibTeX test}
+          \title{\texttt{$REPO} BibTeX test}
           \maketitle
           \noindent
-          \texttt{$PROTOTYPE}
-          \cite{$PROTOTYPE}
+          \texttt{$REPO}
+          \cite{$REPO}
           \bibliography{CITATION}
           \end{document}
           EOF


### PR DESCRIPTION
Previously we were using bash's prefix removal feature to remove the `prototype-` in each repository name to arrive at the desired citation name.  This is not necessary in this repository and others we plan to make in the future, so I am removing it from this workflow.  Now just the repository name itself is appropriate.

Thanks, @caleb-johnson, for noticing this was out of date.