### PR TITLE
Undo the Qiskit 2.2 workaround added in #773

### DIFF
--- a/docs/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
+++ b/docs/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
@@ -328,9 +328,7 @@
    "outputs": [],
    "source": [
     "# Transpile the subeperiments to the backend's instruction set architecture (ISA)\n",
-    "isa_subexperiments = [\n",
-    "    pass_manager.run(subexperiment) for subexperiment in subexperiments\n",
-    "]"
+    "isa_subexperiments = pass_manager.run(subexperiments)"
    ]
   },
   {


### PR DESCRIPTION
This reverts to parallel pass managers, but CI is expected to fail until something else is fixed, either in this package or in Qiskit.