### PR TITLE
[codex] Add regression test for barrier recombination in separate_circuit

### DIFF
--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -357,6 +357,36 @@ class TestTransforms(unittest.TestCase):
                         subcircuits[i].data[j].operation.name, inst.operation.name
                     )
 
+        with self.subTest("Barriers are recombined within a shared partition"):
+            qc = QuantumCircuit(3)
+
+            qc.x([0, 1, 2])
+            qc.barrier()
+            qc.y([0, 1, 2])
+            qc.barrier()
+            qc.z([0, 1, 2])
+            qc.barrier(0)
+
+            subcircuit = separate_circuit(qc, partition_labels="AAB").subcircuits["A"]
+            operation_signature = [
+                (inst.operation.name, len(inst.qubits)) for inst in subcircuit.data
+            ]
+
+            self.assertEqual(
+                [
+                    ("x", 1),
+                    ("x", 1),
+                    ("barrier", 2),
+                    ("y", 1),
+                    ("y", 1),
+                    ("barrier", 2),
+                    ("z", 1),
+                    ("z", 1),
+                    ("barrier", 1),
+                ],
+                operation_signature,
+            )
+
         with self.subTest("Bad partition labels"):
             circuit = QuantumCircuit(2)
             partition_labels = "ABB"


### PR DESCRIPTION
## Summary
- add a regression test for `separate_circuit` when multiple qubits remain in the same partition after barrier splitting
- assert that `_combine_barriers` rebuilds shared barriers instead of leaving duplicated single-qubit barriers behind

## Root cause
`separate_circuit` relies on `_split_barriers` before partitioning, then `_combine_barriers` when reconstructing each subcircuit. The existing barrier coverage only exercised one-qubit subcircuits, so the suite still passed even if `_combine_barriers` was removed.

## Fix
- extend `test_separate_circuit` with a shared-partition barrier case using partition labels `"AAB"`
- verify the resulting subcircuit contains two-qubit barriers in the shared partition, not separate one-qubit barriers

## Tests
- `python -m tox -e py311 -- test/utils/test_transforms.py`
- `python -m tox -e lint`
- temporary mutation check: commenting out `_combine_barriers(tmp_circ)` makes `test/utils/test_transforms.py` fail in the new subtest

## Notes or limitations
- this change is intentionally test-only; it does not modify runtime behavior

Fixes #626
