### PR TITLE
[codex] Ignore explicit global_phase instructions during separation

### DIFF
--- a/qiskit_addon_cutting/utils/transforms.py
+++ b/qiskit_addon_cutting/utils/transforms.py
@@ -225,6 +225,10 @@ def _separate_instructions_by_partition(
     }
 
     for i, inst in enumerate(circuit.data):
+        # Explicit global-phase instructions do not belong to any partition.
+        if inst.operation.name == "global_phase":
+            continue
+
         # Collect the partition labels spanned by the instruction
         partitions_spanned = set()
         for qubit in inst.qubits:

--- a/test/test_cutting_decomposition.py
+++ b/test/test_cutting_decomposition.py
@@ -16,7 +16,7 @@ import unittest
 import pytest
 import numpy as np
 from qiskit import QuantumCircuit
-from qiskit.circuit import CircuitInstruction, Barrier, Clbit
+from qiskit.circuit import CircuitInstruction, Barrier, Clbit, Instruction
 from qiskit.circuit.library import efficient_su2, RXXGate
 from qiskit.circuit.library.standard_gates import CXGate
 from qiskit.quantum_info import PauliList
@@ -256,6 +256,22 @@ class TestCuttingDecomposition(unittest.TestCase):
             assert subcircuit.keys() == {0, 1}
             assert subcircuit[0].num_qubits == 3
             assert subcircuit[1].num_qubits == 1
+        with self.subTest("Zero-qubit global-phase instructions"):
+            qc = QuantumCircuit(2)
+            qc.data.insert(
+                0,
+                CircuitInstruction(
+                    Instruction("global_phase", 0, 0, [0.5]),
+                    qubits=(),
+                    clbits=(),
+                ),
+            )
+            qc.cx(0, 1)
+
+            subcircuits, *_ = partition_problem(qc)
+
+            assert subcircuits.keys() == {0}
+            assert [inst.operation.name for inst in subcircuits[0].data] == ["cx"]
 
     def test_cut_gates(self):
         with self.subTest("simple circuit"):

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -19,6 +19,7 @@ from qiskit.circuit import (
     ClassicalRegister,
     QuantumCircuit,
     CircuitInstruction,
+    Instruction,
 )
 from qiskit.circuit.library import efficient_su2, Measure
 from qiskit.circuit.library.standard_gates import RZZGate
@@ -356,6 +357,37 @@ class TestTransforms(unittest.TestCase):
                     self.assertEqual(
                         subcircuits[i].data[j].operation.name, inst.operation.name
                     )
+
+        with self.subTest("Zero-qubit global-phase instructions are ignored"):
+            qc = QuantumCircuit(2)
+            qc.data.insert(
+                0,
+                CircuitInstruction(
+                    Instruction("global_phase", 0, 0, [0.5]),
+                    qubits=(),
+                    clbits=(),
+                ),
+            )
+            qc.x(0)
+            qc.y(1)
+
+            separated_circuits = separate_circuit(qc)
+
+            self.assertEqual([(0, 0), (1, 0)], separated_circuits.qubit_map)
+            self.assertEqual(
+                ["x"],
+                [
+                    inst.operation.name
+                    for inst in separated_circuits.subcircuits[0].data
+                ],
+            )
+            self.assertEqual(
+                ["y"],
+                [
+                    inst.operation.name
+                    for inst in separated_circuits.subcircuits[1].data
+                ],
+            )
 
         with self.subTest("Bad partition labels"):
             circuit = QuantumCircuit(2)


### PR DESCRIPTION
## Summary
- ignore explicit `global_phase` instructions when assigning operations to circuit partitions
- add regression tests for `separate_circuit()` and `partition_problem()`

## Root cause
Qiskit can materialize a circuit-level global phase as a zero-qubit `global_phase` instruction. `separate_circuit()` assumed every instruction touched exactly one partition, so these zero-qubit instructions left `partitions_spanned` empty and triggered an assertion.

## Fix
- skip explicit `global_phase` instructions while partitioning operations into subcircuits
- keep the change local to `_separate_instructions_by_partition()` so the public APIs inherit the fix without broader refactoring

## Tests
- `tox -e lint`
- `tox -e py311 -- test\\utils\\test_transforms.py test\\test_cutting_decomposition.py test\\test_cutting_workflows.py`

## Notes or limitations
- this patch intentionally handles the explicit `global_phase` instruction reported in #762
- existing repo-wide pylint config warnings about `no-self-use` remain unchanged

Fixes #762
