### PR TITLE
Update dependabot.yml: change pip versioning strategy to "auto"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     labels: ["dependencies"]
-    versioning-strategy: increase
+    versioning-strategy: auto
     schedule:
       interval: "monthly"


### PR DESCRIPTION
This is a test to attempt to deal with the recent flood of dependabot PRs that increase the lower bound unnecessarily.