### PR TITLE
Update dependabot.yml: switch to increase-if-necessary strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     labels: ["dependencies"]
-    versioning-strategy: auto
+    versioning-strategy: increase-if-necessary
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Follow up to #813, which did not go as I had hoped with it attempting to widen the versions for black in #814.