### PR TITLE
Skip zero-qubit global_phase instructions during circuit separation

### DIFF
--- a/qiskit_addon_cutting/utils/transforms.py
+++ b/qiskit_addon_cutting/utils/transforms.py
@@ -225,6 +225,11 @@ def _separate_instructions_by_partition(
     }
 
     for i, inst in enumerate(circuit.data):
+        # A zero-qubit global-phase instruction spans no partition, so it
+        # cannot be assigned to any subcircuit; skip it.
+        if inst.operation.name == "global_phase":
+            continue
+
         # Collect the partition labels spanned by the instruction
         partitions_spanned = set()
         for qubit in inst.qubits:

--- a/releasenotes/notes/fix-global-phase-separation-6b1f4c2d9a0e7e51.yaml
+++ b/releasenotes/notes/fix-global-phase-separation-6b1f4c2d9a0e7e51.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an ``AssertionError`` raised by ``separate_circuit()`` (and, in turn,
+    ``partition_problem()``) when the input circuit contained a zero-qubit
+    ``global_phase`` instruction.  Such an instruction spans no partition, so it
+    is now skipped when assigning operations to subcircuits.

--- a/test/utils/test_transforms.py
+++ b/test/utils/test_transforms.py
@@ -20,7 +20,7 @@ from qiskit.circuit import (
     QuantumCircuit,
     CircuitInstruction,
 )
-from qiskit.circuit.library import efficient_su2, Measure
+from qiskit.circuit.library import efficient_su2, Measure, GlobalPhaseGate
 from qiskit.circuit.library.standard_gates import RZZGate
 
 from qiskit_addon_cutting import partition_circuit_qubits
@@ -356,6 +356,21 @@ class TestTransforms(unittest.TestCase):
                     self.assertEqual(
                         subcircuits[i].data[j].operation.name, inst.operation.name
                     )
+
+        with self.subTest("Zero-qubit global-phase instruction is dropped"):
+            qc = QuantumCircuit(2)
+            qc.append(GlobalPhaseGate(0.5), [])
+            qc.x(0)
+            qc.y(1)
+
+            subcircuits = separate_circuit(qc, "AB").subcircuits
+
+            self.assertEqual(
+                ["x"], [inst.operation.name for inst in subcircuits["A"].data]
+            )
+            self.assertEqual(
+                ["y"], [inst.operation.name for inst in subcircuits["B"].data]
+            )
 
         with self.subTest("Bad partition labels"):
             circuit = QuantumCircuit(2)


### PR DESCRIPTION
## Summary

`separate_circuit()` (and therefore `partition_problem()`) raised an `AssertionError` when the input circuit contained a zero-qubit `global_phase` instruction.

## Details

A `global_phase` instruction acts on no qubits, so it spans no partition and cannot be assigned to a subcircuit. It is now skipped while assigning operations to subcircuits. Global phase does not affect the expectation values the cutting workflow reconstructs, so dropping it during separation is safe.

## Tests

- `pytest test/utils/test_transforms.py test/test_cutting_decomposition.py`
- `ruff check` and `black --check` on the changed files

Fixes #762
